### PR TITLE
Animate library command chips

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -67,6 +67,17 @@
             transform: translateY(var(--animation-distance, -50%));
         }
     }
+
+    @keyframes palette-chip-enter {
+        0% {
+            opacity: 0;
+            transform: translateY(-0.25rem) scale(0.98);
+        }
+        100% {
+            opacity: 1;
+            transform: translateY(0) scale(1);
+        }
+    }
 }
 
 body {
@@ -116,6 +127,39 @@ body {
 
 @utility animate-marquee-vertical {
     animation: marquee-vertical var(--duration, 5s) linear infinite;
+}
+
+.palette-chip-enter {
+    animation: palette-chip-enter 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    transform-origin: top left;
+    will-change: opacity, transform;
+}
+
+.palette-chip-enter:nth-child(2) {
+    animation-delay: 35ms;
+}
+
+.palette-chip-enter:nth-child(3) {
+    animation-delay: 70ms;
+}
+
+.palette-chip-enter:nth-child(4) {
+    animation-delay: 105ms;
+}
+
+.palette-chip-enter:nth-child(5) {
+    animation-delay: 140ms;
+}
+
+.palette-chip-enter:nth-child(6) {
+    animation-delay: 175ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .palette-chip-enter {
+        animation: none;
+        will-change: auto;
+    }
 }
 
 @utility content-auto {

--- a/components/library/library-browser.tsx
+++ b/components/library/library-browser.tsx
@@ -485,7 +485,7 @@ function PaletteChip({
     readonly onRemove: () => void;
 }) {
     return (
-        <span className="inline-flex max-w-[min(100%,12rem)] items-center gap-0.5 rounded-full border border-border/60 bg-background/90 py-0.5 ps-2 pe-0.5 font-medium text-foreground text-xs shadow-xs/5 dark:bg-background/40">
+        <span className="palette-chip-enter inline-flex max-w-[min(100%,12rem)] items-center gap-0.5 rounded-full border border-border/60 bg-background/90 py-0.5 ps-2 pe-0.5 font-medium text-foreground text-xs shadow-xs/5 dark:bg-background/40">
             <span className="min-w-0 truncate">{label}</span>
             <button
                 aria-label={`Remove ${label}`}


### PR DESCRIPTION
This adds a CSS-only entrance animation for the library command chips used for search, filter, group, sort, and layout states. It applies a subtle fade-and-lift motion with a short stagger so newly shown chips feel more intentional without changing behavior. The chip element now opts into that animation, and reduced-motion users get a no-animation fallback.