### PR TITLE
Add title-triggered menu to library cards

### DIFF
--- a/components/library/library-grid.tsx
+++ b/components/library/library-grid.tsx
@@ -20,6 +20,13 @@ import {
     ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { Kbd } from "@/components/ui/kbd";
+import {
+    Menu,
+    MenuItem,
+    MenuPopup,
+    MenuSeparator,
+    MenuTrigger,
+} from "@/components/ui/menu";
 import { Masonry, MasonryItem } from "@/components/ui/masonry";
 import {
     PreviewDrawer,
@@ -136,99 +143,6 @@ interface PreviewMediaProps {
     readonly alt: string;
     readonly fallbackLabel?: string;
     readonly src: string | null;
-}
-
-function itemDomain(url: string): string {
-    try {
-        return new URL(url).hostname.replace(WWW_PREFIX_RE, "") || "Other";
-    } catch {
-        return "Other";
-    }
-}
-
-function itemDateLabel(dateValue: Date | string | null | undefined): string {
-    if (!dateValue) {
-        return "";
-    }
-    const date = dateValue instanceof Date ? dateValue : new Date(dateValue);
-    if (Number.isNaN(date.getTime())) {
-        return "";
-    }
-    return date.toLocaleDateString(undefined, {
-        day: "numeric",
-        month: "short",
-        year: "numeric",
-    });
-}
-
-function fallbackGridStyle(columnCount?: number): CSSProperties | undefined {
-    if (!columnCount) {
-        return undefined;
-    }
-    return {
-        gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
-    };
-}
-
-function itemTitle(item: LibraryItemWithCollections): string {
-    const caption = item.caption?.trim();
-    if (caption) {
-        return caption;
-    }
-
-    if (item.kind === "note") {
-        return "Untitled note";
-    }
-
-    return item.url;
-}
-
-function opengraphPreviewUrl(item: LibraryItemWithCollections): string | null {
-    if (item.thumbnailUrl) {
-        return item.thumbnailUrl;
-    }
-
-    if (item.source !== LibraryItemSource.chrome_bookmarks) {
-        return null;
-    }
-
-    const href = normalizeURL(item.url);
-    if (href === "about:blank") {
-        return null;
-    }
-
-    return `/api/library/opengraph-image?url=${encodeURIComponent(href)}`;
-}
-
-function PreviewMedia({
-    alt,
-    fallbackLabel = "No preview",
-    src,
-}: PreviewMediaProps): ReactElement {
-    const [didFail, setDidFail] = useState(false);
-    const imageSrc = src ?? undefined;
-    const canRenderImage = Boolean(imageSrc) && !didFail;
-
-    if (!canRenderImage) {
-        return (
-            <div className="flex size-full items-center justify-center bg-muted/30 text-muted-foreground text-xs">
-                {fallbackLabel}
-            </div>
-        );
-    }
-
-    return (
-        // biome-ignore lint/a11y/noNoninteractiveElementInteractions: image load failures drive the visual fallback state
-        <img
-            alt={alt}
-            className="size-full object-cover"
-            height={400}
-            loading="lazy"
-            onError={() => setDidFail(true)}
-            src={imageSrc}
-            width={300}
-        />
-    );
 }
 
 function CollectionComboboxPicker({
@@ -420,6 +334,121 @@ function LibraryGridCard({
         }
     };
 
+    const renderCardMenuContent = (menuKind: "context" | "menu") => {
+        const Item = menuKind === "context" ? ContextMenuItem : MenuItem;
+        const Separator =
+            menuKind === "context" ? ContextMenuSeparator : MenuSeparator;
+
+        return (
+            <>
+                <div className="relative mx-auto flex max-w-56 items-center gap-2 pt-2 pb-1.5 pl-2.5 opacity-50">
+                    <span className="block truncate text-xs">
+                        {isNote ? displayTitle : item.url}
+                    </span>
+                </div>
+                <div className="px-2.5 pb-1.5 text-[11px] text-muted-foreground">
+                    <div className="flex items-center justify-between gap-3 py-0.5">
+                        <span>Created</span>
+                        <span className="text-foreground tabular-nums">
+                            {createdLabel}
+                        </span>
+                    </div>
+                    {postedLabel ? (
+                        <div className="flex items-center justify-between gap-3 py-0.5">
+                            <span>Posted</span>
+                            <span className="text-foreground tabular-nums">
+                                {postedLabel}
+                            </span>
+                        </div>
+                    ) : null}
+                </div>
+                <Separator />
+                {isNote ? (
+                    <Item closeOnClick onClick={() => onOpenNote?.(item)}>
+                        <FilePenLineIcon className="size-4.5 text-muted-foreground" />
+                        Edit note
+                    </Item>
+                ) : null}
+                {canPreview ? (
+                    <>
+                        <Item
+                            closeOnClick={false}
+                            onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                setIsPreviewOpen(true);
+                            }}
+                        >
+                            <EyeIcon className="size-4.5 text-muted-foreground" />
+                            Open preview
+                        </Item>
+                        <PreviewDrawer
+                            description={previewDescription}
+                            onOpenChange={setIsPreviewOpen}
+                            open={isPreviewOpen}
+                            title={previewTitle}
+                            url={href}
+                        >
+                            <PreviewDrawerContent />
+                        </PreviewDrawer>
+                    </>
+                ) : null}
+                {isNote ? null : (
+                    <>
+                        <Item closeOnClick onClick={() => onOpenInNewTab?.(item)}>
+                            <ExternalLinkIcon className="size-4.5 text-muted-foreground" />
+                            Open in new tab
+                        </Item>
+                        <Item closeOnClick onClick={() => onOpenHere?.(item)}>
+                            <ArrowUpRightIcon className="size-4.5 text-muted-foreground" />
+                            Open here
+                        </Item>
+                        <Item closeOnClick onClick={() => onCopyLink?.(item)}>
+                            <LinkIcon className="size-4.5 text-muted-foreground" />
+                            Copy link
+                        </Item>
+                        <Item closeOnClick onClick={handleFullscreen}>
+                            <MaximizeIcon className="size-4.5 text-muted-foreground" />
+                            View fullscreen
+                        </Item>
+                        <Item
+                            closeOnClick
+                            disabled={isDownloading}
+                            onClick={handleDownload}
+                        >
+                            <DownloadIcon className="size-4.5 text-muted-foreground" />
+                            {isDownloading
+                                ? "Downloading..."
+                                : "Download media"}
+                        </Item>
+                        <Separator />
+                    </>
+                )}
+                {menuKind === "context" ? (
+                    <ContextMenuItem
+                        className="text-destructive data-highlighted:bg-destructive/10 data-highlighted:text-destructive"
+                        closeOnClick
+                        disabled={isDeletePending}
+                        onClick={() => onDelete?.(item)}
+                    >
+                        <Trash2Icon className="size-4.5" />
+                        {isDeletePending ? "Deleting..." : "Delete"}
+                    </ContextMenuItem>
+                ) : (
+                    <MenuItem
+                        closeOnClick
+                        disabled={isDeletePending}
+                        onClick={() => onDelete?.(item)}
+                        variant="destructive"
+                    >
+                        <Trash2Icon className="size-4.5" />
+                        {isDeletePending ? "Deleting..." : "Delete"}
+                    </MenuItem>
+                )}
+            </>
+        );
+    };
+
     return (
         <ContextMenu>
             <ContextMenuTrigger render={<div className="contents" />}>
@@ -490,110 +519,31 @@ function LibraryGridCard({
                             open={isCollectionPickerOpen}
                             pendingCollectionItemIds={pendingCollectionItemIds}
                         />
-                        <p
-                            className="truncate py-px font-medium text-white text-xs leading-none mix-blend-difference"
-                            title={displayTitle}
-                        >
-                            <Ticker>
-                                {isNote
-                                    ? displayTitle
-                                    : item.caption?.trim() || item.url}
-                            </Ticker>
-                        </p>
+                        <Menu>
+                            <MenuTrigger
+                                render={
+                                    <button
+                                        className="min-w-0 flex-1 truncate rounded-sm py-px text-left font-medium text-white text-xs leading-none mix-blend-difference outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                                        title={displayTitle}
+                                        type="button"
+                                    />
+                                }
+                            >
+                                <Ticker>
+                                    {isNote
+                                        ? displayTitle
+                                        : item.caption?.trim() || item.url}
+                                </Ticker>
+                            </MenuTrigger>
+                            <MenuPopup>
+                                {renderCardMenuContent("menu")}
+                            </MenuPopup>
+                        </Menu>
                     </div>
                 </article>
             </ContextMenuTrigger>
             <ContextMenuPopup>
-                <div className="relative mx-auto flex max-w-56 items-center gap-2 pt-2 pb-1.5 pl-2.5 opacity-50">
-                    <span className="block truncate text-xs">
-                        {isNote ? displayTitle : item.url}
-                    </span>
-                </div>
-                <div className="px-2.5 pb-1.5 text-[11px] text-muted-foreground">
-                    <div className="flex items-center justify-between gap-3 py-0.5">
-                        <span>Created</span>
-                        <span className="text-foreground tabular-nums">
-                            {createdLabel}
-                        </span>
-                    </div>
-                    {postedLabel ? (
-                        <div className="flex items-center justify-between gap-3 py-0.5">
-                            <span>Posted</span>
-                            <span className="text-foreground tabular-nums">
-                                {postedLabel}
-                            </span>
-                        </div>
-                    ) : null}
-                </div>
-                <ContextMenuSeparator />
-                {isNote ? (
-                    <ContextMenuItem onClick={() => onOpenNote?.(item)}>
-                        <FilePenLineIcon className="size-4.5 text-muted-foreground" />
-                        Edit note
-                    </ContextMenuItem>
-                ) : null}
-                {canPreview ? (
-                    <>
-                        <ContextMenuItem
-                            closeOnClick={false}
-                            onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                setIsPreviewOpen(true);
-                            }}
-                        >
-                            <EyeIcon className="size-4.5 text-muted-foreground" />
-                            Open preview
-                        </ContextMenuItem>
-                        <PreviewDrawer
-                            description={previewDescription}
-                            onOpenChange={setIsPreviewOpen}
-                            open={isPreviewOpen}
-                            title={previewTitle}
-                            url={href}
-                        >
-                            <PreviewDrawerContent />
-                        </PreviewDrawer>
-                    </>
-                ) : null}
-                {isNote ? null : (
-                    <>
-                        <ContextMenuItem onClick={() => onOpenInNewTab?.(item)}>
-                            <ExternalLinkIcon className="size-4.5 text-muted-foreground" />
-                            Open in new tab
-                        </ContextMenuItem>
-                        <ContextMenuItem onClick={() => onOpenHere?.(item)}>
-                            <ArrowUpRightIcon className="size-4.5 text-muted-foreground" />
-                            Open here
-                        </ContextMenuItem>
-                        <ContextMenuItem onClick={() => onCopyLink?.(item)}>
-                            <LinkIcon className="size-4.5 text-muted-foreground" />
-                            Copy link
-                        </ContextMenuItem>
-                        <ContextMenuItem onClick={handleFullscreen}>
-                            <MaximizeIcon className="size-4.5 text-muted-foreground" />
-                            View fullscreen
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                            disabled={isDownloading}
-                            onClick={handleDownload}
-                        >
-                            <DownloadIcon className="size-4.5 text-muted-foreground" />
-                            {isDownloading
-                                ? "Downloading..."
-                                : "Download media"}
-                        </ContextMenuItem>
-                        <ContextMenuSeparator />
-                    </>
-                )}
-                <ContextMenuItem
-                    className="text-destructive data-highlighted:bg-destructive/10 data-highlighted:text-destructive"
-                    disabled={isDeletePending}
-                    onClick={() => onDelete?.(item)}
-                >
-                    <Trash2Icon className="size-4.5" />
-                    {isDeletePending ? "Deleting..." : "Delete"}
-                </ContextMenuItem>
+                {renderCardMenuContent("context")}
             </ContextMenuPopup>
         </ContextMenu>
     );


### PR DESCRIPTION
## Summary
- make each library card title/caption open the same actions available in the existing context menu
- keep the shared menu content local to  so the card owns its own state and behavior
- preserve the current context-menu actions while adding the tap-friendly menu trigger