### PR TITLE
[perf/preview] cut preview route cold-start and cache-miss cost

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture
+
+High-level notes for areas where the design is non-obvious. Prefer reading the
+code and its neighboring tests; this file only records the seams that are easy
+to miss.
+
+## Preview proxy (`app/api/preview`)
+
+`GET /api/preview?url=&type=image|video&delivery=proxy|redirect` resolves a
+bookmark URL to a preview image or video and either **proxies** the bytes or
+**redirects** (307) to the upstream asset.
+
+### Request flow
+
+```
+GET /api/preview
+  ├─ parse target (sync: length, standalone URL, http/https)
+  ├─ type=video
+  │    ├─ Redis GET cobalt-preview:<sha16>  → hit → proxy|redirect
+  │    ├─ isCobaltHost? else 404
+  │    ├─ parsePublicHttpUrl (SSRF DNS check)
+  │    └─ resolveCobaltPreview (lazy import) → cache → proxy|redirect
+  └─ type=image (default)
+       ├─ Redis GET preview-image:<sha16> → hit → signed-URL grace → proxy|redirect
+       ├─ parsePublicHttpUrl (SSRF DNS check)
+       └─ resolveImagePreview
+            ├─ TikTok → oEmbed thumbnail
+            ├─ else fetch page (manual redirects, max 3)
+            │    ├─ if body is already a supported image MIME → use URL as image
+            │    └─ else stream body (≤2 MiB) → extractPreviewImageUrls (lazy)
+            └─ cache ResolvedImage → proxy|redirect
+```
+
+### Hot path vs cold modules
+
+| Module | When loaded | Why |
+| --- | --- | --- |
+| `lib/common/redis` | first cache op | always on success path |
+| `lib/common/server-net` | first public-URL check | SSRF DNS |
+| `./extract` (htmlparser2) | **image cache-miss HTML only** | lazy; not on hit/video |
+| `cobalt/service` | **video cache-miss only** | lazy; `isCobaltHost` stays static |
+| `link-preview-js` | **never** (route) | replaced by `extract.ts`; still used by chrome paste action |
+
+### Caching
+
+| Key | TTL | Value |
+| --- | --- | --- |
+| `preview-image:<sha256(url)[0:16]>` | 300s | `{ imageUrl, pageUrl }` JSON |
+| `cobalt-preview:<sha256(url)[0:16]>` | 300s | video URL string |
+
+Browser `Cache-Control`: `max-age=60, s-maxage=300, stale-while-revalidate=60`.
+CDN: `Vercel-CDN-Cache-Control` max-age 300 + `Vercel-Cache-Tag: preview:{type}:{sha16}`.
+
+Signed image URLs with `x-expires` are treated as expired within 300s of
+expiry (`isSignedUrlExpired`) so a cached entry cannot outlive a signed asset.
+
+### SSRF and redirects
+
+- `parsePublicHttpUrl` rejects non-http(s), localhost/private literals, and
+  hostnames that resolve to non-public-unicast addresses.
+- Redirects are followed manually (`redirect: "manual"`, `MAX_REDIRECTS=3`).
+  Each **new hostname** in the chain is re-checked via `parsePublicHttpUrl`;
+  repeats of a host already validated **in that request** skip a second
+  `dns.lookup` (request-scoped set, not a process-wide positive DNS cache —
+  the latter would widen DNS-rebinding windows across requests).
+
+### Body / MIME caps
+
+| Cap | Limit |
+| --- | --- |
+| Metadata HTML body | 2 MiB |
+| Proxied image | 10 MiB (`Content-Length` gate) |
+| Proxied video | 200 MiB |
+| Image MIME | avif, bmp, gif, jpeg, png, webp (no SVG) |
+| Video MIME | mp4, quicktime, webm |
+

--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -1,7 +1,5 @@
 import { createHash } from "node:crypto";
 
-import * as z from "zod";
-
 import { abortAfterAny, isAbortError } from "@/lib/common/abort";
 import { MIME_TYPES } from "@/lib/common/constants";
 import { createLogger } from "@/lib/common/logs/console/logger";
@@ -10,11 +8,6 @@ import { getRedisClient } from "@/lib/common/redis";
 import { parsePublicHttpUrl } from "@/lib/common/server-net";
 import { fetchWithTimeout } from "@/lib/common/timeout";
 import { parseStandaloneUrl } from "@/lib/common/url";
-import { extractPreviewImageUrls } from "./extract";
-import {
-    classifyCobaltError,
-    resolveCobaltPreview,
-} from "@/lib/integrations/cobalt/service";
 import { isCobaltHost } from "@/lib/integrations/cobalt/utils";
 import {
     tiktokOembedThumbnailUrl,
@@ -87,10 +80,55 @@ interface ResolvedImage {
     pageUrl: string;
 }
 
-const ResolvedImageSchema = z.object({
-    imageUrl: z.string(),
-    pageUrl: z.string(),
-});
+// Lazy-loaded only on the HTML cache-miss path (not cache-hit / video).
+// On import failure, clear the cached promise so the next request can retry.
+let extractPreviewImageUrlsPromise: Promise<
+    typeof import("./extract").extractPreviewImageUrls
+> | null = null;
+
+function loadExtractPreviewImageUrls() {
+    extractPreviewImageUrlsPromise ??= import("./extract")
+        .then((mod) => mod.extractPreviewImageUrls)
+        .catch((error: unknown) => {
+            extractPreviewImageUrlsPromise = null;
+            throw error;
+        });
+    return extractPreviewImageUrlsPromise;
+}
+
+// Lazy-loaded only on the video cache-miss path.
+let cobaltServicePromise: Promise<
+    typeof import("@/lib/integrations/cobalt/service")
+> | null = null;
+
+function loadCobaltService() {
+    cobaltServicePromise ??= import("@/lib/integrations/cobalt/service").catch(
+        (error: unknown) => {
+            cobaltServicePromise = null;
+            throw error;
+        }
+    );
+    return cobaltServicePromise;
+}
+
+function parseResolvedImage(value: unknown): ResolvedImage | null {
+    if (!(typeof value === "object" && value !== null)) {
+        return null;
+    }
+    if (!("imageUrl" in value && "pageUrl" in value)) {
+        return null;
+    }
+    if (
+        typeof value.imageUrl !== "string" ||
+        typeof value.pageUrl !== "string"
+    ) {
+        return null;
+    }
+    return {
+        imageUrl: value.imageUrl,
+        pageUrl: value.pageUrl,
+    };
+}
 
 export async function GET(request: Request): Promise<Response> {
     const requestUrl = new URL(request.url);
@@ -280,10 +318,11 @@ async function resolveImagePreview(
 
     // extractPreviewImageUrls replaces link-preview-js's cheerio/parse5 DOM
     // parse with an htmlparser2 streaming scan (~10x faster on a 150 KiB page).
-    // It mirrors getImages precedence exactly; parity is covered by
-    // app/api/preview/extract.test.ts. baseUrl is the final post-redirect URL
-    // (or the original target) so relative og:image/<img> resolve identically.
+    // Lazy-imported so cache-hit / video cold starts skip htmlparser2.
+    // baseUrl is the final post-redirect URL (or the original target) so
+    // relative og:image/<img> resolve identically.
     const baseUrl = pageResponse.url || targetHref;
+    const extractPreviewImageUrls = await loadExtractPreviewImageUrls();
     const imageUrl = getFirstHttpUrl(
         extractPreviewImageUrls(previewBody, baseUrl)
     );
@@ -417,6 +456,7 @@ async function resolveVideoPreview(
     try {
         const videoResult = await resolveVideo(targetUrl, signal);
         if (!videoResult?.videoUrl) {
+            const { classifyCobaltError } = await loadCobaltService();
             const errorCategory = classifyCobaltError(videoResult?.errorCode);
             if (errorCategory === "rate_limited") {
                 return textResponse(
@@ -457,6 +497,7 @@ async function resolveVideoPreview(
 
 async function resolveVideo(targetUrl: URL, signal?: AbortSignal) {
     const targetHref = targetUrl.href;
+    const { resolveCobaltPreview } = await loadCobaltService();
     const result = await resolveCobaltPreview(targetHref, signal);
     if (result.status === "SUCCESS" && result.videoPreviewUrl) {
         await writeToRedis(
@@ -562,6 +603,10 @@ async function fetchWithRedirects(
         : { redirect: "manual" as const };
 
     let publicUrl = initialUrl;
+    // Hosts SSRF-checked in this chain only. Same-host multi-hop redirects
+    // skip a second dns.lookup without a process-wide positive DNS cache
+    // (which would widen rebinding across requests).
+    const hostsValidatedThisChain = new Set<string>();
 
     for (
         let redirectCount = 0;
@@ -569,11 +614,15 @@ async function fetchWithRedirects(
         redirectCount += 1
     ) {
         if (redirectCount > 0) {
-            const validated = await parsePublicHttpUrl(publicUrl.href);
-            if (!validated) {
-                return textResponse("Invalid URL", 400);
+            const hostname = publicUrl.hostname;
+            if (!hostsValidatedThisChain.has(hostname)) {
+                const validated = await parsePublicHttpUrl(publicUrl.href);
+                if (!validated) {
+                    return textResponse("Invalid URL", 400);
+                }
+                publicUrl = validated;
+                hostsValidatedThisChain.add(validated.hostname);
             }
-            publicUrl = validated;
         }
 
         const response = await fetchWithTimeout(
@@ -779,14 +828,16 @@ async function readCachedImagePreview(
     } catch {
         return null;
     }
-    const parsed = ResolvedImageSchema.safeParse(parsedJson);
-    if (!parsed.success) {
+    // Lightweight shape check replaces zod on the cache-hit hot path; the
+    // schema only required two strings.
+    const parsed = parseResolvedImage(parsedJson);
+    if (!parsed) {
         return null;
     }
-    if (isSignedUrlExpired(parsed.data.imageUrl)) {
+    if (isSignedUrlExpired(parsed.imageUrl)) {
         return null;
     }
-    return parsed.data;
+    return parsed;
 }
 
 async function writeCachedImagePreview(


### PR DESCRIPTION
## Summary
- Document and land preview-route perf work: htmlparser2 extract (already on main) + harness/RESULTS evidence (cold-start, path micro-benches, plow load, CPU profiles, Redis TTL/grace).
- Lazy-load `extract` (htmlparser2) and cobalt service only on miss paths; drop zod on Redis cache-hit shape check.
- Request-scoped same-host skip in `fetchWithRedirects` (no process-wide positive DNS cache — self-review rejected that for SSRF rebinding).

## Measured (see `perf/preview/RESULTS.md`)
| Path | Baseline → After |
| --- | --- |
| cold-start | ~103 → ~63 ms p50 |
| cache-miss image | ~17 → ~1.5 ms |
| redirect-chain | ~17 → ~1.6 ms |
| cache-hit | ~0.010 ms (flat) |

## Test plan
- [x] `bun perf/preview/harness.ts all` (cold-start + dns + paths)
- [x] `bun test app/api/preview/extract.test.ts` (19/19)
- [x] `bun perf/preview/cache-reliability.ts` (12/12)
- [x] `bun lint` + `bun type-check`
- [ ] Optional: re-run plow 50/100/500 RPS × 60s against `next dev` if desired (tables already in RESULTS from prior run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved preview loading efficiency, especially for cached requests and cold starts.
  * Reduced unnecessary processing when resolving image and video previews.

* **Reliability & Security**
  * Strengthened redirect validation and protection against unsafe destinations.
  * Improved handling of cached image URLs nearing expiration.

* **Documentation**
  * Added architecture and performance documentation for the preview system.

* **Testing**
  * Added benchmarks and verification tools covering preview performance, extraction, caching, and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->