### PR TITLE
fix(integrations): resolve OAuth tokens across linked accounts

### DIFF
--- a/app/api/integrations/google-photos/picker/import/route.ts
+++ b/app/api/integrations/google-photos/picker/import/route.ts
@@ -10,6 +10,7 @@ import {
     collectGooglePhotosImportCandidates,
     importGooglePhotosCandidates,
 } from "@/lib/integrations/google-photos/service";
+import { GOOGLE_PHOTOS_PERMISSION_MESSAGE } from "@/lib/integrations/google-photos/shared";
 import { autoTagLibraryItemsByIds } from "@/lib/intelligence";
 import { after } from "next/server";
 import * as z from "zod";
@@ -92,14 +93,12 @@ export async function POST(request: Request) {
             error instanceof IntegrationApiError &&
             error.data.integrationId === "google-photos"
         ) {
+            const status = error.data.status ?? 500;
             const message =
-                error.data.status === 401
-                    ? "Your Google account needs Photos permission. Please sign out and sign back in to reconnect."
+                status === 401 || status === 403
+                    ? GOOGLE_PHOTOS_PERMISSION_MESSAGE
                     : error.message;
-            return Response.json(
-                { error: message },
-                { status: error.data.status ?? 500 }
-            );
+            return Response.json({ error: message }, { status });
         }
         throw error;
     }

--- a/app/api/integrations/google-photos/picker/import/route.ts
+++ b/app/api/integrations/google-photos/picker/import/route.ts
@@ -15,6 +15,7 @@ import { after } from "next/server";
 import * as z from "zod";
 
 const bodySchema = z.object({
+    accountId: z.string().min(1),
     sessionId: z.string().min(1),
 });
 
@@ -35,7 +36,9 @@ export async function POST(request: Request) {
     }
 
     const accessToken = await resolveProviderAccountAccessToken({
+        accountId: parsedBody.data.accountId,
         providerId: "google",
+        userId,
     });
     if (!accessToken) {
         return Response.json(

--- a/app/api/integrations/google-photos/picker/session/route.ts
+++ b/app/api/integrations/google-photos/picker/session/route.ts
@@ -1,47 +1,88 @@
 import { requireRouteUserId } from "@/lib/auth/session";
-import { resolveProviderAccountAccessToken } from "@/lib/integrations/account";
+import {
+    eachProviderAccountAccess,
+    resolveProviderAccountAccessToken,
+} from "@/lib/integrations/account";
 import { IntegrationApiError } from "@/lib/integrations/error";
 import {
     createPickerSession,
     getPickerSession,
 } from "@/lib/integrations/google-photos/api";
 import { mapPickerSessionToViewModel } from "@/lib/integrations/google-photos/service";
+import { GOOGLE_PHOTOS_PICKER_SCOPE } from "@/lib/integrations/google-photos/shared";
+
+function photosAuthErrorResponse(error: IntegrationApiError): Response {
+    const message =
+        error.data.status === 401
+            ? "Your Google account needs Photos permission. Please sign out and sign back in to reconnect."
+            : error.message;
+    return Response.json(
+        { error: message },
+        { status: error.data.status ?? 500 }
+    );
+}
+
+function isPhotosAuthFailure(error: unknown): error is IntegrationApiError {
+    return (
+        error instanceof IntegrationApiError &&
+        error.data.integrationId === "google-photos" &&
+        (error.data.status === 401 || error.data.status === 403)
+    );
+}
 
 export async function POST() {
     const sessionResult = await requireRouteUserId();
     if (sessionResult instanceof Response) {
         return sessionResult;
     }
+    const { userId } = sessionResult;
 
-    const accessToken = await resolveProviderAccountAccessToken({
+    let attemptedAccountCount = 0;
+    let lastPhotosAuthError: IntegrationApiError | null = null;
+
+    for await (const access of eachProviderAccountAccess({
         providerId: "google",
-    });
-    if (!accessToken) {
+        requiredScope: GOOGLE_PHOTOS_PICKER_SCOPE,
+        userId,
+    })) {
+        attemptedAccountCount += 1;
+        try {
+            const pickerSession = await createPickerSession(access.accessToken);
+            return Response.json(
+                mapPickerSessionToViewModel(pickerSession, access.accountId)
+            );
+        } catch (error) {
+            if (isPhotosAuthFailure(error)) {
+                lastPhotosAuthError = error;
+                continue;
+            }
+            if (
+                error instanceof IntegrationApiError &&
+                error.data.integrationId === "google-photos"
+            ) {
+                return photosAuthErrorResponse(error);
+            }
+            throw error;
+        }
+    }
+
+    if (lastPhotosAuthError) {
+        return photosAuthErrorResponse(lastPhotosAuthError);
+    }
+
+    if (attemptedAccountCount === 0) {
         return Response.json(
             { error: "Missing Google access token. Reconnect Google first." },
             { status: 403 }
         );
     }
 
-    try {
-        const pickerSession = await createPickerSession(accessToken);
-        return Response.json(mapPickerSessionToViewModel(pickerSession));
-    } catch (error) {
-        if (
-            error instanceof IntegrationApiError &&
-            error.data.integrationId === "google-photos"
-        ) {
-            const message =
-                error.data.status === 401
-                    ? "Your Google account needs Photos permission. Please sign out and sign back in to reconnect."
-                    : error.message;
-            return Response.json(
-                { error: message },
-                { status: error.data.status ?? 500 }
-            );
-        }
-        throw error;
-    }
+    return Response.json(
+        {
+            error: "Your Google account needs Photos permission. Please sign out and sign back in to reconnect.",
+        },
+        { status: 401 }
+    );
 }
 
 export async function GET(request: Request) {
@@ -49,6 +90,7 @@ export async function GET(request: Request) {
     if (sessionResult instanceof Response) {
         return sessionResult;
     }
+    const { userId } = sessionResult;
 
     const url = new URL(request.url);
     const id = url.searchParams.get("id");
@@ -56,8 +98,15 @@ export async function GET(request: Request) {
         return Response.json({ error: "Missing session id" }, { status: 400 });
     }
 
+    const accountId = url.searchParams.get("accountId");
+    if (!accountId) {
+        return Response.json({ error: "Missing account id" }, { status: 400 });
+    }
+
     const accessToken = await resolveProviderAccountAccessToken({
+        accountId,
         providerId: "google",
+        userId,
     });
     if (!accessToken) {
         return Response.json(
@@ -68,16 +117,15 @@ export async function GET(request: Request) {
 
     try {
         const pickerSession = await getPickerSession(accessToken, id);
-        return Response.json(mapPickerSessionToViewModel(pickerSession));
+        return Response.json(
+            mapPickerSessionToViewModel(pickerSession, accountId)
+        );
     } catch (error) {
         if (
             error instanceof IntegrationApiError &&
             error.data.integrationId === "google-photos"
         ) {
-            return Response.json(
-                { error: error.message },
-                { status: error.data.status ?? 500 }
-            );
+            return photosAuthErrorResponse(error);
         }
         throw error;
     }

--- a/app/api/integrations/google-photos/picker/session/route.ts
+++ b/app/api/integrations/google-photos/picker/session/route.ts
@@ -9,17 +9,18 @@ import {
     getPickerSession,
 } from "@/lib/integrations/google-photos/api";
 import { mapPickerSessionToViewModel } from "@/lib/integrations/google-photos/service";
-import { GOOGLE_PHOTOS_PICKER_SCOPE } from "@/lib/integrations/google-photos/shared";
+import {
+    GOOGLE_PHOTOS_PERMISSION_MESSAGE,
+    GOOGLE_PHOTOS_PICKER_SCOPE,
+} from "@/lib/integrations/google-photos/shared";
 
 function photosAuthErrorResponse(error: IntegrationApiError): Response {
+    const status = error.data.status ?? 500;
     const message =
-        error.data.status === 401
-            ? "Your Google account needs Photos permission. Please sign out and sign back in to reconnect."
+        status === 401 || status === 403
+            ? GOOGLE_PHOTOS_PERMISSION_MESSAGE
             : error.message;
-    return Response.json(
-        { error: message },
-        { status: error.data.status ?? 500 }
-    );
+    return Response.json({ error: message }, { status });
 }
 
 function isPhotosAuthFailure(error: unknown): error is IntegrationApiError {
@@ -37,7 +38,6 @@ export async function POST() {
     }
     const { userId } = sessionResult;
 
-    let attemptedAccountCount = 0;
     let lastPhotosAuthError: IntegrationApiError | null = null;
 
     for await (const access of eachProviderAccountAccess({
@@ -45,7 +45,6 @@ export async function POST() {
         requiredScope: GOOGLE_PHOTOS_PICKER_SCOPE,
         userId,
     })) {
-        attemptedAccountCount += 1;
         try {
             const pickerSession = await createPickerSession(access.accessToken);
             return Response.json(
@@ -70,18 +69,9 @@ export async function POST() {
         return photosAuthErrorResponse(lastPhotosAuthError);
     }
 
-    if (attemptedAccountCount === 0) {
-        return Response.json(
-            { error: "Missing Google access token. Reconnect Google first." },
-            { status: 403 }
-        );
-    }
-
     return Response.json(
-        {
-            error: "Your Google account needs Photos permission. Please sign out and sign back in to reconnect.",
-        },
-        { status: 401 }
+        { error: "Missing Google access token. Reconnect Google first." },
+        { status: 403 }
     );
 }
 

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -2,6 +2,7 @@ import { getStripeClient, getStripeWebhookSecret } from "@/lib/billing/client";
 import { getPlanPriceIds } from "@/lib/billing/prices";
 import { APP_NAME, BASE_URL } from "@/lib/common/constants";
 import { createLogger } from "@/lib/common/logs/console/logger";
+import { GOOGLE_PHOTOS_PICKER_SCOPE } from "@/lib/integrations/google-photos/shared";
 import { NOTION_API_VERSION } from "@/lib/integrations/notion/api";
 import { seedBuiltInAutomationsForUser } from "@/lib/intelligence/automations/service";
 import { prisma } from "@/prisma";
@@ -40,8 +41,6 @@ const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24; // 24 hours (how often to refre
 const GOOGLE_CLIENT_ID = requiredEnv("GOOGLE_CLIENT_ID");
 const GOOGLE_CLIENT_SECRET = requiredEnv("GOOGLE_CLIENT_SECRET");
 
-const GOOGLE_PHOTOS_SCOPE =
-    "https://www.googleapis.com/auth/photospicker.mediaitems.readonly";
 const log = createLogger("Auth:server");
 
 // ---------------------------------------------------------------------------
@@ -445,7 +444,7 @@ export const auth = betterAuth({
             clientId: GOOGLE_CLIENT_ID,
             clientSecret: GOOGLE_CLIENT_SECRET,
             prompt: "select_account consent",
-            scope: ["openid", "email", "profile", GOOGLE_PHOTOS_SCOPE],
+            scope: ["openid", "email", "profile", GOOGLE_PHOTOS_PICKER_SCOPE],
         },
     },
     trustedOrigins: TRUSTED_ORIGINS,

--- a/lib/integrations/account.ts
+++ b/lib/integrations/account.ts
@@ -4,17 +4,16 @@ import { auth } from "@/lib/auth/server";
 import { createLogger } from "@/lib/common/logs/console/logger";
 import { prisma } from "@/prisma";
 import { headers } from "next/headers";
+import {
+    compareProviderAccountsForScopePreference,
+    getProviderTokenApiErrorCode,
+    isSoftProviderTokenResolutionFailure,
+} from "./provider-account-resolution";
 import { listIntegrationAccountProviderIds } from "./support";
 
 const log = createLogger("integrations:account");
 
 const LINKED_INTEGRATION_ACCOUNT_LIMIT = 50;
-const OAUTH_SCOPE_SEPARATOR_PATTERN = /[\s,]+/;
-
-const SOFT_TOKEN_RESOLUTION_ERROR_CODES = new Set([
-    "ACCOUNT_NOT_FOUND",
-    "FAILED_TO_GET_ACCESS_TOKEN",
-]);
 
 export interface ResolvedProviderAccess {
     accessToken: string;
@@ -61,7 +60,7 @@ export async function getIntegrationAccountId(
 }
 
 async function tryGetAccessToken(
-    accountId: string | undefined,
+    accountId: string,
     providerId: string
 ): Promise<string | null> {
     const tokenResponse = await auth.api.getAccessToken({
@@ -75,57 +74,44 @@ async function tryGetAccessToken(
     return tokenResponse?.accessToken ?? null;
 }
 
-function getApiErrorCode(error: unknown): string | null {
-    if (
-        typeof error !== "object" ||
-        error === null ||
-        !("body" in error) ||
-        typeof error.body !== "object" ||
-        error.body === null ||
-        !("code" in error.body) ||
-        typeof error.body.code !== "string"
-    ) {
-        return null;
-    }
-    return error.body.code;
-}
-
-function isSoftTokenResolutionFailure(error: unknown): boolean {
-    const code = getApiErrorCode(error);
-    return code !== null && SOFT_TOKEN_RESOLUTION_ERROR_CODES.has(code);
-}
-
-function accountHasScope(
-    scope: string | null | undefined,
-    requiredScope: string
-): boolean {
-    if (!scope) {
-        return false;
-    }
-    return scope.split(OAUTH_SCOPE_SEPARATOR_PATTERN).includes(requiredScope);
-}
-
-function compareAccountsForScopePreference(
-    left: { accountId: string; scope: string | null },
-    right: { accountId: string; scope: string | null },
-    requiredScope: string | undefined
-): number {
-    if (requiredScope) {
-        const leftHasScope = accountHasScope(left.scope, requiredScope);
-        const rightHasScope = accountHasScope(right.scope, requiredScope);
-        if (leftHasScope !== rightHasScope) {
-            return leftHasScope ? -1 : 1;
+async function tryResolveAccountAccess(
+    accountId: string,
+    providerId: string,
+    softFailureMessage: string
+): Promise<ResolvedProviderAccess | null> {
+    try {
+        const accessToken = await tryGetAccessToken(accountId, providerId);
+        if (!accessToken) {
+            return null;
         }
+        return { accessToken, accountId };
+    } catch (error) {
+        if (isSoftProviderTokenResolutionFailure(error)) {
+            log.debug(softFailureMessage, {
+                accountId,
+                code: getProviderTokenApiErrorCode(error),
+                providerId,
+            });
+            return null;
+        }
+        log.error("Hard failure resolving provider account access", {
+            accountId,
+            error,
+            providerId,
+        });
+        throw error;
     }
-    return left.accountId.localeCompare(right.accountId);
 }
 
 /**
  * Resolves a valid access token for an OAuth provider account.
  *
+ * {@link args.userId} is always required so pinned accounts are ownership-
+ * checked and multi-account scans stay scoped to the session user.
+ *
  * When a specific {@link args.accountId} is given, only that account is
- * attempted. When {@link args.userId} is given without an accountId, ALL
- * accounts matching the provider are tried — essential when a user has
+ * attempted (after verifying it belongs to {@link args.userId}). Otherwise
+ * ALL accounts matching the provider are tried — essential when a user has
  * linked multiple Google accounts via accountLinking, so an arbitrary row
  * isn't picked while another holds a valid token.
  *
@@ -137,67 +123,46 @@ export async function resolveProviderAccountAccess(args: {
     accountId?: string;
     providerId: string;
     requiredScope?: string;
-    userId?: string;
+    userId: string;
 }): Promise<ResolvedProviderAccess | null> {
     if (args.accountId) {
-        if (args.userId) {
-            const ownedAccount = await prisma.account.findFirst({
-                select: { accountId: true },
-                where: {
-                    accountId: args.accountId,
-                    providerId: args.providerId,
-                    userId: args.userId,
-                },
-            });
-            if (!ownedAccount) {
-                log.debug("Pinned account is not owned by user", {
-                    accountId: args.accountId,
-                    providerId: args.providerId,
-                    userId: args.userId,
-                });
-                return null;
-            }
-        }
-
-        try {
-            const accessToken = await tryGetAccessToken(
-                args.accountId,
-                args.providerId
-            );
-            if (!accessToken) {
-                return null;
-            }
-            return { accessToken, accountId: args.accountId };
-        } catch (error) {
-            if (isSoftTokenResolutionFailure(error)) {
-                log.debug("Pinned account access token is unusable", {
-                    accountId: args.accountId,
-                    code: getApiErrorCode(error),
-                    providerId: args.providerId,
-                });
-                return null;
-            }
-            throw error;
-        }
-    }
-
-    if (args.userId) {
-        for await (const access of eachProviderAccountAccess({
-            providerId: args.providerId,
-            requiredScope: args.requiredScope,
-            userId: args.userId,
-        })) {
-            return access;
-        }
-
-        log.warn("No valid access token found across all accounts", {
-            providerId: args.providerId,
-            requiredScope: args.requiredScope,
-            userId: args.userId,
+        const ownedAccount = await prisma.account.findFirst({
+            select: { accountId: true },
+            where: {
+                accountId: args.accountId,
+                providerId: args.providerId,
+                userId: args.userId,
+            },
         });
-        return null;
+        if (!ownedAccount) {
+            log.warn("Pinned account is not owned by user", {
+                accountId: args.accountId,
+                providerId: args.providerId,
+                userId: args.userId,
+            });
+            return null;
+        }
+
+        return tryResolveAccountAccess(
+            args.accountId,
+            args.providerId,
+            "Pinned account access token is unusable"
+        );
     }
 
+    for await (const access of eachProviderAccountAccess({
+        providerId: args.providerId,
+        requiredScope: args.requiredScope,
+        userId: args.userId,
+    })) {
+        return access;
+    }
+
+    log.warn("No valid access token found across all accounts", {
+        providerId: args.providerId,
+        requiredScope: args.requiredScope,
+        userId: args.userId,
+    });
     return null;
 }
 
@@ -223,29 +188,22 @@ export async function* eachProviderAccountAccess(args: {
 
     const orderedAccounts = args.requiredScope
         ? accounts.toSorted((left, right) =>
-              compareAccountsForScopePreference(left, right, args.requiredScope)
+              compareProviderAccountsForScopePreference(
+                  left,
+                  right,
+                  args.requiredScope
+              )
           )
         : accounts;
 
     for (const account of orderedAccounts) {
-        try {
-            const accessToken = await tryGetAccessToken(
-                account.accountId,
-                args.providerId
-            );
-            if (accessToken) {
-                yield { accessToken, accountId: account.accountId };
-            }
-        } catch (error) {
-            if (isSoftTokenResolutionFailure(error)) {
-                log.debug("Skipping account with unusable access token", {
-                    accountId: account.accountId,
-                    code: getApiErrorCode(error),
-                    providerId: args.providerId,
-                });
-                continue;
-            }
-            throw error;
+        const access = await tryResolveAccountAccess(
+            account.accountId,
+            args.providerId,
+            "Skipping account with unusable access token"
+        );
+        if (access) {
+            yield access;
         }
     }
 }
@@ -254,11 +212,8 @@ export async function resolveProviderAccountAccessToken(args: {
     accountId?: string;
     providerId: string;
     requiredScope?: string;
-    userId?: string;
+    userId: string;
 }): Promise<string | null> {
-    if (!(args.accountId || args.userId)) {
-        return tryGetAccessToken(undefined, args.providerId);
-    }
     const resolved = await resolveProviderAccountAccess(args);
     return resolved?.accessToken ?? null;
 }

--- a/lib/integrations/account.ts
+++ b/lib/integrations/account.ts
@@ -1,11 +1,25 @@
 import "server-only";
 
 import { auth } from "@/lib/auth/server";
+import { createLogger } from "@/lib/common/logs/console/logger";
 import { prisma } from "@/prisma";
 import { headers } from "next/headers";
 import { listIntegrationAccountProviderIds } from "./support";
 
+const log = createLogger("integrations:account");
+
 const LINKED_INTEGRATION_ACCOUNT_LIMIT = 50;
+const OAUTH_SCOPE_SEPARATOR_PATTERN = /[\s,]+/;
+
+const SOFT_TOKEN_RESOLUTION_ERROR_CODES = new Set([
+    "ACCOUNT_NOT_FOUND",
+    "FAILED_TO_GET_ACCESS_TOKEN",
+]);
+
+export interface ResolvedProviderAccess {
+    accessToken: string;
+    accountId: string;
+}
 
 /**
  * Lists linked OAuth accounts for integrations the app supports.
@@ -46,17 +60,205 @@ export async function getIntegrationAccountId(
     return account?.accountId ?? null;
 }
 
-export async function resolveProviderAccountAccessToken(args: {
-    accountId?: string;
-    providerId: string;
-}): Promise<string | null> {
+async function tryGetAccessToken(
+    accountId: string | undefined,
+    providerId: string
+): Promise<string | null> {
     const tokenResponse = await auth.api.getAccessToken({
         body: {
-            accountId: args.accountId,
-            providerId: args.providerId,
+            accountId,
+            providerId,
         },
         headers: await headers(),
     });
 
     return tokenResponse?.accessToken ?? null;
+}
+
+function getApiErrorCode(error: unknown): string | null {
+    if (
+        typeof error !== "object" ||
+        error === null ||
+        !("body" in error) ||
+        typeof error.body !== "object" ||
+        error.body === null ||
+        !("code" in error.body) ||
+        typeof error.body.code !== "string"
+    ) {
+        return null;
+    }
+    return error.body.code;
+}
+
+function isSoftTokenResolutionFailure(error: unknown): boolean {
+    const code = getApiErrorCode(error);
+    return code !== null && SOFT_TOKEN_RESOLUTION_ERROR_CODES.has(code);
+}
+
+function accountHasScope(
+    scope: string | null | undefined,
+    requiredScope: string
+): boolean {
+    if (!scope) {
+        return false;
+    }
+    return scope.split(OAUTH_SCOPE_SEPARATOR_PATTERN).includes(requiredScope);
+}
+
+function compareAccountsForScopePreference(
+    left: { accountId: string; scope: string | null },
+    right: { accountId: string; scope: string | null },
+    requiredScope: string | undefined
+): number {
+    if (requiredScope) {
+        const leftHasScope = accountHasScope(left.scope, requiredScope);
+        const rightHasScope = accountHasScope(right.scope, requiredScope);
+        if (leftHasScope !== rightHasScope) {
+            return leftHasScope ? -1 : 1;
+        }
+    }
+    return left.accountId.localeCompare(right.accountId);
+}
+
+/**
+ * Resolves a valid access token for an OAuth provider account.
+ *
+ * When a specific {@link args.accountId} is given, only that account is
+ * attempted. When {@link args.userId} is given without an accountId, ALL
+ * accounts matching the provider are tried — essential when a user has
+ * linked multiple Google accounts via accountLinking, so an arbitrary row
+ * isn't picked while another holds a valid token.
+ *
+ * When {@link args.requiredScope} is set, accounts whose stored scope grants
+ * it are tried first. Soft per-account token failures continue to the next
+ * account; session/config failures rethrow.
+ */
+export async function resolveProviderAccountAccess(args: {
+    accountId?: string;
+    providerId: string;
+    requiredScope?: string;
+    userId?: string;
+}): Promise<ResolvedProviderAccess | null> {
+    if (args.accountId) {
+        if (args.userId) {
+            const ownedAccount = await prisma.account.findFirst({
+                select: { accountId: true },
+                where: {
+                    accountId: args.accountId,
+                    providerId: args.providerId,
+                    userId: args.userId,
+                },
+            });
+            if (!ownedAccount) {
+                log.debug("Pinned account is not owned by user", {
+                    accountId: args.accountId,
+                    providerId: args.providerId,
+                    userId: args.userId,
+                });
+                return null;
+            }
+        }
+
+        try {
+            const accessToken = await tryGetAccessToken(
+                args.accountId,
+                args.providerId
+            );
+            if (!accessToken) {
+                return null;
+            }
+            return { accessToken, accountId: args.accountId };
+        } catch (error) {
+            if (isSoftTokenResolutionFailure(error)) {
+                log.debug("Pinned account access token is unusable", {
+                    accountId: args.accountId,
+                    code: getApiErrorCode(error),
+                    providerId: args.providerId,
+                });
+                return null;
+            }
+            throw error;
+        }
+    }
+
+    if (args.userId) {
+        for await (const access of eachProviderAccountAccess({
+            providerId: args.providerId,
+            requiredScope: args.requiredScope,
+            userId: args.userId,
+        })) {
+            return access;
+        }
+
+        log.warn("No valid access token found across all accounts", {
+            providerId: args.providerId,
+            requiredScope: args.requiredScope,
+            userId: args.userId,
+        });
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Yields successfully resolved access tokens for each linked account,
+ * preferring accounts that grant {@link args.requiredScope}. Soft token
+ * failures skip to the next account; hard auth/config errors rethrow.
+ */
+export async function* eachProviderAccountAccess(args: {
+    providerId: string;
+    requiredScope?: string;
+    userId: string;
+}): AsyncGenerator<ResolvedProviderAccess> {
+    const accounts = await prisma.account.findMany({
+        orderBy: { accountId: "asc" },
+        select: { accountId: true, scope: true },
+        take: LINKED_INTEGRATION_ACCOUNT_LIMIT,
+        where: {
+            providerId: args.providerId,
+            userId: args.userId,
+        },
+    });
+
+    const orderedAccounts = args.requiredScope
+        ? accounts.toSorted((left, right) =>
+              compareAccountsForScopePreference(left, right, args.requiredScope)
+          )
+        : accounts;
+
+    for (const account of orderedAccounts) {
+        try {
+            const accessToken = await tryGetAccessToken(
+                account.accountId,
+                args.providerId
+            );
+            if (accessToken) {
+                yield { accessToken, accountId: account.accountId };
+            }
+        } catch (error) {
+            if (isSoftTokenResolutionFailure(error)) {
+                log.debug("Skipping account with unusable access token", {
+                    accountId: account.accountId,
+                    code: getApiErrorCode(error),
+                    providerId: args.providerId,
+                });
+                continue;
+            }
+            throw error;
+        }
+    }
+}
+
+export async function resolveProviderAccountAccessToken(args: {
+    accountId?: string;
+    providerId: string;
+    requiredScope?: string;
+    userId?: string;
+}): Promise<string | null> {
+    if (!(args.accountId || args.userId)) {
+        return tryGetAccessToken(undefined, args.providerId);
+    }
+    const resolved = await resolveProviderAccountAccess(args);
+    return resolved?.accessToken ?? null;
 }

--- a/lib/integrations/google-photos/client.ts
+++ b/lib/integrations/google-photos/client.ts
@@ -79,6 +79,7 @@ async function createPickerSessionRequest(): Promise<SessionCreateResponse> {
 
 async function pollUntilMediaSelected(
     sessionId: string,
+    accountId: string,
     timeoutIn: string | null
 ): Promise<void> {
     const startedAt = Date.now();
@@ -99,7 +100,7 @@ async function pollUntilMediaSelected(
             }
 
             const response = await fetch(
-                `/api/integrations/google-photos/picker/session?id=${encodeURIComponent(sessionId)}`,
+                `/api/integrations/google-photos/picker/session?id=${encodeURIComponent(sessionId)}&accountId=${encodeURIComponent(accountId)}`,
                 { method: "GET" }
             );
             const raw = await readJsonOrNull(response);
@@ -136,11 +137,14 @@ async function pollUntilMediaSelected(
     );
 }
 
-async function importSelectedMedia(sessionId: string): Promise<ImportResponse> {
+async function importSelectedMedia(
+    sessionId: string,
+    accountId: string
+): Promise<ImportResponse> {
     const response = await fetch(
         "/api/integrations/google-photos/picker/import",
         {
-            body: JSON.stringify({ sessionId }),
+            body: JSON.stringify({ accountId, sessionId }),
             headers: { "Content-Type": "application/json" },
             method: "POST",
         }
@@ -183,9 +187,13 @@ export async function executeGooglePhotosPickerFlow(): Promise<string> {
     window.open(createPayload.pickerUri, "_blank", "noopener,noreferrer");
     await pollUntilMediaSelected(
         createPayload.sessionId,
+        createPayload.accountId,
         createPayload.timeoutIn
     );
-    const importPayload = await importSelectedMedia(createPayload.sessionId);
+    const importPayload = await importSelectedMedia(
+        createPayload.sessionId,
+        createPayload.accountId
+    );
 
     return `Imported ${importPayload.importedCount} item${importPayload.importedCount === 1 ? "" : "s"}.`;
 }

--- a/lib/integrations/google-photos/service.ts
+++ b/lib/integrations/google-photos/service.ts
@@ -14,6 +14,7 @@ import { pickerPollIntervalMs, withPickerAutoclose } from "./api";
 const log = createLogger("integrations:google-photos");
 
 export interface PickerSessionViewModel {
+    accountId: string;
     mediaItemsSet?: boolean;
     pickerUri: string | null;
     pollIntervalMs: number;
@@ -22,9 +23,11 @@ export interface PickerSessionViewModel {
 }
 
 export function mapPickerSessionToViewModel(
-    session: GooglePhotosPickerSession
+    session: GooglePhotosPickerSession,
+    accountId: string
 ): PickerSessionViewModel {
     return {
+        accountId,
         mediaItemsSet: Boolean(session.mediaItemsSet),
         pickerUri: session.pickerUri
             ? withPickerAutoclose(session.pickerUri)

--- a/lib/integrations/google-photos/shared.ts
+++ b/lib/integrations/google-photos/shared.ts
@@ -57,7 +57,11 @@ export type GooglePhotosMediaItemsPage = z.infer<
     typeof GooglePhotosMediaItemsPageSchema
 >;
 
+export const GOOGLE_PHOTOS_PICKER_SCOPE =
+    "https://www.googleapis.com/auth/photospicker.mediaitems.readonly";
+
 export const SessionCreateResponseSchema = z.object({
+    accountId: z.string().min(1),
     error: z.string().optional(),
     pickerUri: z.string().nullable(),
     pollIntervalMs: z.number(),

--- a/lib/integrations/google-photos/shared.ts
+++ b/lib/integrations/google-photos/shared.ts
@@ -60,6 +60,9 @@ export type GooglePhotosMediaItemsPage = z.infer<
 export const GOOGLE_PHOTOS_PICKER_SCOPE =
     "https://www.googleapis.com/auth/photospicker.mediaitems.readonly";
 
+export const GOOGLE_PHOTOS_PERMISSION_MESSAGE =
+    "Your Google account needs Photos permission. Sign out and sign back in to reconnect.";
+
 export const SessionCreateResponseSchema = z.object({
     accountId: z.string().min(1),
     error: z.string().optional(),

--- a/lib/integrations/notion/actions.ts
+++ b/lib/integrations/notion/actions.ts
@@ -117,6 +117,7 @@ async function sendToNotion(
     const accessToken = await resolveProviderAccountAccessToken({
         accountId,
         providerId: NOTION_PROVIDER_ID,
+        userId: auth.userId,
     });
     if (!accessToken) {
         return {

--- a/lib/integrations/oauth-import/service.ts
+++ b/lib/integrations/oauth-import/service.ts
@@ -51,6 +51,7 @@ export async function runOAuthImportService<
     const accessToken = await resolveProviderAccountAccessToken({
         accountId,
         providerId: args.providerId,
+        userId: args.userId,
     });
     if (!accessToken) {
         throw new IntegrationConnectionError({

--- a/lib/integrations/provider-account-resolution.test.ts
+++ b/lib/integrations/provider-account-resolution.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+    accountHasOAuthScope,
+    compareProviderAccountsForScopePreference,
+    getProviderTokenApiErrorCode,
+    isSoftProviderTokenResolutionFailure,
+} from "./provider-account-resolution";
+
+describe("accountHasOAuthScope", () => {
+    test("matches space-separated scopes", () => {
+        expect(
+            accountHasOAuthScope(
+                "openid email https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+                "https://www.googleapis.com/auth/photospicker.mediaitems.readonly"
+            )
+        ).toBe(true);
+    });
+
+    test("matches comma-separated scopes", () => {
+        expect(accountHasOAuthScope("a,b,c", "b")).toBe(true);
+    });
+
+    test("rejects missing scope and empty input", () => {
+        expect(accountHasOAuthScope("openid email", "photos")).toBe(false);
+        expect(accountHasOAuthScope(null, "photos")).toBe(false);
+        expect(accountHasOAuthScope(undefined, "photos")).toBe(false);
+        expect(accountHasOAuthScope("", "photos")).toBe(false);
+    });
+});
+
+describe("compareProviderAccountsForScopePreference", () => {
+    const withScope = {
+        accountId: "b-account",
+        scope: "openid photos",
+    };
+    const withoutScope = {
+        accountId: "a-account",
+        scope: "openid",
+    };
+
+    test("prefers accounts that grant the required scope", () => {
+        expect(
+            compareProviderAccountsForScopePreference(
+                withoutScope,
+                withScope,
+                "photos"
+            )
+        ).toBeGreaterThan(0);
+        expect(
+            compareProviderAccountsForScopePreference(
+                withScope,
+                withoutScope,
+                "photos"
+            )
+        ).toBeLessThan(0);
+    });
+
+    test("falls back to accountId order when scope ties or is unset", () => {
+        expect(
+            compareProviderAccountsForScopePreference(
+                withoutScope,
+                withScope,
+                undefined
+            )
+        ).toBe(withoutScope.accountId.localeCompare(withScope.accountId));
+        expect(
+            compareProviderAccountsForScopePreference(
+                { accountId: "z", scope: "photos" },
+                { accountId: "a", scope: "photos" },
+                "photos"
+            )
+        ).toBe("z".localeCompare("a"));
+    });
+
+    test("sorts scoped accounts first", () => {
+        const ordered = [withoutScope, withScope].toSorted((left, right) =>
+            compareProviderAccountsForScopePreference(left, right, "photos")
+        );
+        expect(ordered.map((account) => account.accountId)).toEqual([
+            "b-account",
+            "a-account",
+        ]);
+    });
+});
+
+describe("isSoftProviderTokenResolutionFailure", () => {
+    test("treats known Better Auth token codes as soft", () => {
+        expect(
+            isSoftProviderTokenResolutionFailure({
+                body: { code: "ACCOUNT_NOT_FOUND" },
+            })
+        ).toBe(true);
+        expect(
+            isSoftProviderTokenResolutionFailure({
+                body: { code: "FAILED_TO_GET_ACCESS_TOKEN" },
+            })
+        ).toBe(true);
+    });
+
+    test("rejects unknown codes and malformed errors", () => {
+        expect(
+            isSoftProviderTokenResolutionFailure({
+                body: { code: "SESSION_EXPIRED" },
+            })
+        ).toBe(false);
+        expect(isSoftProviderTokenResolutionFailure(new Error("boom"))).toBe(
+            false
+        );
+        expect(isSoftProviderTokenResolutionFailure(null)).toBe(false);
+        expect(getProviderTokenApiErrorCode({ body: { code: 1 } })).toBeNull();
+    });
+});

--- a/lib/integrations/provider-account-resolution.ts
+++ b/lib/integrations/provider-account-resolution.ts
@@ -1,0 +1,51 @@
+const OAUTH_SCOPE_SEPARATOR_PATTERN = /[\s,]+/;
+
+const SOFT_TOKEN_RESOLUTION_ERROR_CODES = new Set([
+    "ACCOUNT_NOT_FOUND",
+    "FAILED_TO_GET_ACCESS_TOKEN",
+]);
+
+export function accountHasOAuthScope(
+    scope: string | null | undefined,
+    requiredScope: string
+): boolean {
+    if (!scope) {
+        return false;
+    }
+    return scope.split(OAUTH_SCOPE_SEPARATOR_PATTERN).includes(requiredScope);
+}
+
+export function compareProviderAccountsForScopePreference(
+    left: { accountId: string; scope: string | null },
+    right: { accountId: string; scope: string | null },
+    requiredScope: string | undefined
+): number {
+    if (requiredScope) {
+        const leftHasScope = accountHasOAuthScope(left.scope, requiredScope);
+        const rightHasScope = accountHasOAuthScope(right.scope, requiredScope);
+        if (leftHasScope !== rightHasScope) {
+            return leftHasScope ? -1 : 1;
+        }
+    }
+    return left.accountId.localeCompare(right.accountId);
+}
+
+export function getProviderTokenApiErrorCode(error: unknown): string | null {
+    if (
+        typeof error !== "object" ||
+        error === null ||
+        !("body" in error) ||
+        typeof error.body !== "object" ||
+        error.body === null ||
+        !("code" in error.body) ||
+        typeof error.body.code !== "string"
+    ) {
+        return null;
+    }
+    return error.body.code;
+}
+
+export function isSoftProviderTokenResolutionFailure(error: unknown): boolean {
+    const code = getProviderTokenApiErrorCode(error);
+    return code !== null && SOFT_TOKEN_RESOLUTION_ERROR_CODES.has(code);
+}


### PR DESCRIPTION
## Summary
- Resolve provider access by trying **all** linked OAuth accounts for a user (preferring accounts that grant a required scope), instead of an arbitrary token row
- Pin Google Photos picker create/poll/import to the winning `accountId` so session + import use the same Google account
- Pass `userId` into token resolution for Notion send and OAuth import so pinned accounts are ownership-checked
- Share `GOOGLE_PHOTOS_PICKER_SCOPE` from google-photos shared module (auth + picker)

## Test plan
- [ ] User with a single Google account: Photos picker create → select → import still works
- [ ] User with multiple linked Google accounts where only one has Photos picker scope: picker succeeds on the scoped account
- [ ] User with multiple Google accounts where the first row has a dead token but another is valid: soft failures skip, valid account used
- [ ] Picker poll/import reject missing `accountId`; import uses the same account that created the session
- [ ] Notion “send to” and other OAuth imports still resolve tokens for the session user
- [ ] Reconnect / 401 Photos messaging still surfaces when no account can authorize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Photos Picker sessions now support selecting and tracking a specific linked account.
  * Picker imports and status checks retain the associated account throughout the flow.
  * Google Photos access is automatically matched to accounts with the required permissions.

* **Bug Fixes**
  * Improved handling of missing access, expired authorization, and account-specific authentication errors.
  * Added validation to prevent incomplete Picker session and import requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->