### PR TITLE
feat(library): collections UX, gap metrics, and smarter AI filters

### DIFF
--- a/components/library/browser.tsx
+++ b/components/library/browser.tsx
@@ -19,6 +19,7 @@ import {
     type CommandSuggestion,
     type PaletteStackEntry,
 } from "@/components/library/composer";
+import { isHoverHotkeySurface } from "@/components/library/hover-hotkey-surface";
 import {
     NoteEditor,
     NoteHeader,
@@ -1749,11 +1750,11 @@ function buildCollectionPaletteItems({
 }): CommandPaletteItem[] {
     return [
         {
-            active: selectedCollectionIds.length === 0,
             description:
                 selectedCollectionIds.length === 0
                     ? "Show items from every collection"
                     : "Clear the selected collection filters",
+            isActive: selectedCollectionIds.length === 0,
             label: "Collections: All collections",
             onSelect: wrapOnSelect(onClearCollectionFilters),
             value: "filter collection all",
@@ -1762,11 +1763,11 @@ function buildCollectionPaletteItems({
             const isActive = selectedCollectionIds.includes(collection.id);
 
             return {
-                active: isActive,
                 description: buildCollectionPaletteDescription(
                     collection,
                     isActive
                 ),
+                isActive,
                 label: `Collection: ${collection.name}`,
                 onSelect: wrapOnSelect(() =>
                     onToggleCollectionSelection(collection.id)
@@ -1791,7 +1792,7 @@ function PaletteChip({
     });
 
     return (
-        <span className="inline-flex max-w-[min(100%,12rem)] items-center gap-0.5 rounded-full border border-border/60 bg-background/80 py-0.5 ps-2 pe-0.5 font-medium text-foreground text-xs shadow-xs/5 backdrop-blur-md backdrop-saturate-150">
+        <span className="inline-flex max-w-[min(100%,12rem)] items-center gap-0.5 rounded-full border border-border/60 bg-background/90 py-0.5 ps-2 pe-0.5 font-medium text-foreground text-xs shadow-xs/5">
             <span className="min-w-0 max-w-full truncate text-xs">{label}</span>
             <Button
                 aria-label={`Remove ${label}`}
@@ -1903,7 +1904,7 @@ function PaletteAttachmentChip({
                 <AttachmentPreviewCardTrigger
                     render={
                         <Attachment
-                            className="max-w-[min(100%,12rem)] rounded-full border-border/60 bg-background/80 py-0.5 ps-1 pe-0.5 text-xs shadow-xs/5 backdrop-blur-md backdrop-saturate-150"
+                            className="max-w-[min(100%,12rem)] rounded-full border-border/60 bg-background/90 py-0.5 ps-1 pe-0.5 text-xs shadow-xs/5"
                             data={attachment}
                             onRemove={handleRemove}
                         />
@@ -1972,12 +1973,20 @@ interface BrowserResultsContextValue {
     favoriteItemIdSet: ReadonlySet<string>;
     /**
      * Tracks the id of the grid card currently under the pointer so
-     * global hotkeys (e.g. `S` to open the collection picker) can target
-     * the hovered card instead of requiring keyboard focus on the card,
-     * which is unreachable while the pointer is elsewhere. Mirrors the
-     * `hoveredCollectionRef` pattern used by the collections list.
+     * global hotkeys (e.g. `S` to open the collection picker, `⌥F` /
+     * `⌥E` / `⌘⌫` for card actions) can target the hovered card instead
+     * of requiring keyboard focus on the card, which is unreachable
+     * while the pointer is elsewhere. Mirrors the `hoveredCollectionRef`
+     * pattern used by the collections list. While a card's menu or
+     * context menu is open, the card keeps this id pinned so menu
+     * shortcut labels still work after the pointer moves into the popup.
      */
     hoveredItemIdRef: React.RefObject<string | null>;
+    /**
+     * When non-null, a card menu/picker has claimed the hover target.
+     * Other cards must not overwrite `hoveredItemIdRef` until released.
+     */
+    hoverPinnedItemIdRef: React.RefObject<string | null>;
     onCollapseAllSections?: () => void;
     onCopyLink: (item: LibraryItemWithCollections) => void;
     onCreateCollectionFromResults?: () => void;
@@ -2575,6 +2584,7 @@ function BrowserCardProvider({ children }: React.PropsWithChildren) {
         collections,
         favoriteItemIdSet,
         hoveredItemIdRef,
+        hoverPinnedItemIdRef,
         onCopyLink,
         onDelete,
         onFindSimilar,
@@ -2593,6 +2603,7 @@ function BrowserCardProvider({ children }: React.PropsWithChildren) {
                 collections,
                 favoriteItemIdSet,
                 hoveredItemIdRef,
+                hoverPinnedItemIdRef,
                 onCopyLink,
                 onDelete,
                 onFindSimilar,
@@ -2718,10 +2729,10 @@ function buildSearchPaletteGroups({
     if (draft) {
         const shouldDefaultToAskCache = isMultiWordQuery(draft);
         const addSearchItem: CommandPaletteItem = {
-            active: draftAlreadyIncluded,
             description: draftAlreadyIncluded
                 ? "Already included in the search"
                 : "Add this search term",
+            isActive: draftAlreadyIncluded,
             label: `Search "${draft}"`,
             onSelect: () => {
                 setSearchTerms((current) =>
@@ -2753,8 +2764,8 @@ function buildSearchPaletteGroups({
         groups.push({
             items: [
                 ...searchTerms.map((term) => ({
-                    active: true,
                     description: "Active stacked search term",
+                    isActive: true,
                     label: `Search: ${truncateLabel(term, 28)}`,
                     onSelect: () =>
                         setSearchTerms((current) => removeValue(current, term)),
@@ -2787,7 +2798,7 @@ function buildSearchPaletteGroups({
                     continue;
                 }
                 collectionItems.push({
-                    active: selectedCollectionIds.includes(collection.id),
+                    isActive: selectedCollectionIds.includes(collection.id),
                     label: collection.name,
                     onSelect: applyCollectionFilter(() =>
                         onToggleCollectionSelection(collection.id)
@@ -2852,9 +2863,6 @@ function buildSearchPaletteGroups({
                                       <History className="size-4 shrink-0 text-muted-foreground" />
                                       <span className="truncate">
                                           Pick up where you left off
-                                      </span>
-                                      <span className="text-muted-foreground/60 text-xs tabular-nums">
-                                          {lastVisitedItemIds.length}
                                       </span>
                                   </div>
                               ),
@@ -3187,11 +3195,11 @@ function buildPaletteGroups({
         groups.push({
             items: [
                 {
-                    active: duplicatesFilterEnabled,
                     description:
                         duplicateItemCount > 0
                             ? `Show ${duplicateItemCount} bookmark${duplicateItemCount === 1 ? "" : "s"} that share a URL`
                             : "No duplicate bookmarks found right now",
+                    isActive: duplicatesFilterEnabled,
                     label: "Duplicates",
                     onSelect: applyAndStay(() =>
                         setDuplicatesFilterEnabled(!duplicatesFilterEnabled)
@@ -3199,9 +3207,9 @@ function buildPaletteGroups({
                     value: "filter duplicates",
                 },
                 {
-                    active: unreachableFilterEnabled,
                     description:
                         "Check which bookmark links fail to load or time out",
+                    isActive: unreachableFilterEnabled,
                     label: "Unreachable links",
                     onSelect: applyAndStay(() =>
                         setUnreachableFilterEnabled(!unreachableFilterEnabled)
@@ -3214,15 +3222,15 @@ function buildPaletteGroups({
         groups.push({
             items: [
                 {
-                    active: sourceFilters.length === 0,
                     description: "Show every source",
+                    isActive: sourceFilters.length === 0,
                     label: "Source: All sources",
                     onSelect: applyAndStay(() => setSourceFilters([])),
                     value: "filter source all",
                 },
                 ...PALETTE_SOURCE_FILTER_OPTIONS.map((option) => ({
-                    active: sourceFilters.includes(option.value),
                     description: "Toggle this source in the filter stack",
+                    isActive: sourceFilters.includes(option.value),
                     label: `Source: ${option.label}`,
                     onSelect: applyAndStay(() =>
                         setSourceFilters((current) =>
@@ -3237,11 +3245,11 @@ function buildPaletteGroups({
         groups.push({
             items: [
                 {
-                    active:
-                        collectionMembershipFilter ===
-                        DEFAULT_COLLECTION_MEMBERSHIP_FILTER,
                     description:
                         "Show items whether or not they are in collections",
+                    isActive:
+                        collectionMembershipFilter ===
+                        DEFAULT_COLLECTION_MEMBERSHIP_FILTER,
                     label: "Collections: All items",
                     onSelect: applyAndStay(() =>
                         setCollectionMembershipFilter(
@@ -3251,9 +3259,9 @@ function buildPaletteGroups({
                     value: "filter collections all",
                 },
                 {
-                    active: collectionMembershipFilter === "in-collections",
                     description:
                         "Show only items that belong to at least one collection",
+                    isActive: collectionMembershipFilter === "in-collections",
                     label: "Collections: In collections",
                     onSelect: applyAndStay(() =>
                         setCollectionMembershipFilter("in-collections")
@@ -3261,9 +3269,10 @@ function buildPaletteGroups({
                     value: "filter collections in",
                 },
                 {
-                    active: collectionMembershipFilter === "not-in-collections",
                     description:
                         "Show only items that do not belong to any collection",
+                    isActive:
+                        collectionMembershipFilter === "not-in-collections",
                     label: "Collections: Not in collections",
                     onSelect: applyAndStay(() =>
                         setCollectionMembershipFilter("not-in-collections")
@@ -3285,14 +3294,14 @@ function buildPaletteGroups({
         });
         groups.push({
             items: domainOptions.map((option) => ({
-                active:
-                    option.value === ALL_DOMAIN_FILTER
-                        ? domainFilters.length === 0
-                        : domainFilters.includes(option.value),
                 description:
                     option.value === ALL_DOMAIN_FILTER
                         ? "Show items from every domain"
                         : "Toggle this domain in the filter stack",
+                isActive:
+                    option.value === ALL_DOMAIN_FILTER
+                        ? domainFilters.length === 0
+                        : domainFilters.includes(option.value),
                 label: `Domain: ${option.label}`,
                 onSelect: applyAndStay(() =>
                     option.value === ALL_DOMAIN_FILTER
@@ -3313,8 +3322,8 @@ function buildPaletteGroups({
             { items: [backItem], label: "Navigation" },
             {
                 items: PALETTE_GROUP_OPTIONS.map((option) => ({
-                    active: groupBy === option.value,
                     description: "Organize the grid into sections",
+                    isActive: groupBy === option.value,
                     label: option.label,
                     onSelect: applyAndReturn(() => setGroupBy(option.value)),
                     value: `group ${option.value}`,
@@ -3329,8 +3338,8 @@ function buildPaletteGroups({
             { items: [backItem], label: "Navigation" },
             {
                 items: PALETTE_SORT_OPTIONS.map((option) => ({
-                    active: sortMode === option.value,
                     description: "Change the ordering within the current view",
+                    isActive: sortMode === option.value,
                     label: option.label,
                     onSelect: applyAndReturn(() => setSortMode(option.value)),
                     value: `sort ${option.value}`,
@@ -3345,11 +3354,11 @@ function buildPaletteGroups({
             { items: [backItem], label: "Navigation" },
             {
                 items: PALETTE_COLUMN_OPTIONS.map((option) => ({
-                    active: columnCountMode === option.value,
                     description:
                         option.value === "auto"
                             ? "Choose the best column count for the available width"
                             : "Force a specific number of columns",
+                    isActive: columnCountMode === option.value,
                     label: option.label,
                     onSelect: applyAndReturn(() =>
                         setColumnCountMode(option.value)
@@ -3389,9 +3398,8 @@ function filterCommandItems(
     );
 
     if (input.lastVisitedItemIds.length > 0) {
-        list = list.filter((item) =>
-            input.lastVisitedItemIds.includes(item.id)
-        );
+        const lastVisitedIdSet = new Set(input.lastVisitedItemIds);
+        list = list.filter((item) => lastVisitedIdSet.has(item.id));
     }
 
     if (input.duplicatesFilterEnabled) {
@@ -4036,6 +4044,7 @@ type LibraryGridCardContextValue = Pick<
     | "collections"
     | "favoriteItemIdSet"
     | "hoveredItemIdRef"
+    | "hoverPinnedItemIdRef"
     | "onCopyLink"
     | "onDelete"
     | "onFindSimilar"
@@ -4076,10 +4085,8 @@ interface LibraryGridCardMenuProps {
     createdLabel: string;
     href: string;
     isDownloading: boolean;
-    isOpen: boolean;
     item: LibraryItemWithCollections;
     kind: "context" | "menu";
-    onClose: () => void;
     onDownload: () => void;
     onZoomIn: () => void;
     previewImageUrl: string | null;
@@ -4335,7 +4342,7 @@ function PreviewColorBadge({ value }: { value: string }) {
                 {isCopied ? (
                     <>
                         <Check className="size-3 text-black invert" />
-                        <span className="absolute -bottom-4 text-nowrap rounded-full bg-white text-[11px] text-success-foreground">
+                        <span className="absolute -bottom-4 text-nowrap rounded-full bg-background text-[11px] text-success-foreground">
                             Copied!
                         </span>
                     </>
@@ -4368,10 +4375,8 @@ function CardMenu({
     createdLabel,
     href,
     isDownloading,
-    isOpen,
     item,
     kind,
-    onClose,
     onDownload,
     onZoomIn,
     previewImageUrl,
@@ -4394,67 +4399,6 @@ function CardMenu({
     const isDeletePending = pendingDeleteItemId === item.id;
     const SourceIcon = getSourceIcon(item.source);
     const canPreview = !isNote && toValidUrl(href) !== FALLBACK_URL;
-
-    useHotkeys(
-        "alt+f",
-        (event: KeyboardEvent) => {
-            event.preventDefault();
-            onItemFavoriteToggle(item);
-            onClose();
-        },
-        {
-            description: "Toggle favorite on selected item",
-            enabled: isOpen && !isDeletePending,
-            enableOnContentEditable: false,
-            enableOnFormTags: false,
-        },
-        [isOpen, isDeletePending, item, onClose, onItemFavoriteToggle]
-    );
-
-    const quickLookTriggerId = React.useId();
-
-    useHotkeys(
-        "alt+e",
-        (event: KeyboardEvent) => {
-            event.preventDefault();
-            if (canPreview) {
-                openQuickLookDrawer(
-                    {
-                        description: itemDomain(item.url),
-                        title: getItemTitle(item),
-                        url: item.url,
-                    },
-                    quickLookTriggerId
-                );
-            }
-            onClose();
-        },
-        {
-            description: "Quick look on selected item",
-            enabled: isOpen && !isDeletePending && canPreview,
-            enableOnContentEditable: false,
-            enableOnFormTags: false,
-        },
-        [isOpen, isDeletePending, canPreview, item, onClose, quickLookTriggerId]
-    );
-
-    useHotkeys(
-        "mod+backspace",
-        (event: KeyboardEvent) => {
-            event.preventDefault();
-            if (!isDeletePending && onDelete) {
-                onDelete(item);
-            }
-            onClose();
-        },
-        {
-            description: "Delete selected item",
-            enabled: isOpen && !isDeletePending,
-            enableOnContentEditable: false,
-            enableOnFormTags: false,
-        },
-        [isOpen, isDeletePending, item, onClose, onDelete]
-    );
 
     const handleItemFavoriteToggle = useStableCallback(() =>
         onItemFavoriteToggle(item)
@@ -4479,6 +4423,12 @@ function CardMenu({
     const handleWayback90 = useStableCallback(() =>
         openExternal(
             `https://web.archive.org/web/${formatWaybackDate(-90)}/${item.url}`
+        )
+    );
+
+    const handleWayback180 = useStableCallback(() =>
+        openExternal(
+            `https://web.archive.org/web/${formatWaybackDate(-180)}/${item.url}`
         )
     );
 
@@ -4582,7 +4532,7 @@ function CardMenu({
                         ) : (
                             <ExternalLinkIcon className="size-4.5 text-muted-foreground" />
                         )}
-                        Open in new tab
+                        Open in New Tab
                         <ArrowUpRight className="ml-auto size-4 text-muted-foreground" />
                     </Item>
                     <Item onClick={handleCopyLink}>
@@ -4608,7 +4558,7 @@ function CardMenu({
                     </MenuSubTrigger>
                     <MenuSubPopup>
                         <MenuGroup>
-                            <MenuGroupLabel>Web archive</MenuGroupLabel>
+                            <MenuGroupLabel>Wayback Machine</MenuGroupLabel>
                             <MenuItem onClick={handleWayback30}>
                                 <History className="size-4 text-muted-foreground" />
                                 1 month ago
@@ -4616,6 +4566,10 @@ function CardMenu({
                             <MenuItem onClick={handleWayback90}>
                                 <History className="size-4 text-muted-foreground" />
                                 3 months ago
+                            </MenuItem>
+                            <MenuItem onClick={handleWayback180}>
+                                <History className="size-4 text-muted-foreground" />
+                                6 months ago
                             </MenuItem>
                             <MenuItem onClick={handleWayback365}>
                                 <History className="size-4 text-muted-foreground" />
@@ -4643,6 +4597,7 @@ function CardMenu({
 function MediaCard({ item }: LibraryGridCardProps) {
     const {
         hoveredItemIdRef,
+        hoverPinnedItemIdRef,
         onOpenInNewTab,
         onOpenNote,
         openPickerItemId,
@@ -4661,23 +4616,44 @@ function MediaCard({ item }: LibraryGridCardProps) {
     const noteExcerpt = getNoteExcerpt(item.noteContentText);
     const displayTitle = getItemTitle(item);
     const { markVisited, isLastVisited } = useLastVisited();
-
-    const closeCardMenu = useStableCallback(() => {
-        setIsCardMenuOpen(false);
-    });
-
-    const closeContextMenu = useStableCallback(() => {
-        setIsContextMenuOpen(false);
-    });
+    const isPickerOpen = openPickerItemId === item.id;
+    const isHoverPinned = isCardMenuOpen || isContextMenuOpen || isPickerOpen;
+    const isPointerOverCardRef = React.useRef(false);
 
     React.useEffect(
         () => () => {
             if (hoveredItemIdRef.current === item.id) {
                 hoveredItemIdRef.current = null;
             }
+            if (hoverPinnedItemIdRef.current === item.id) {
+                hoverPinnedItemIdRef.current = null;
+            }
         },
-        [hoveredItemIdRef, item.id]
+        [hoveredItemIdRef, hoverPinnedItemIdRef, item.id]
     );
+
+    // Keep the hover target pinned while a menu/picker is open so shortcuts
+    // still resolve after the pointer moves into the popup — and so sibling
+    // cards cannot steal the target via mouseEnter. On unpin, drop the hover
+    // target unless the pointer is still over this card (mouseLeave is a no-op
+    // while pinned, so a stale id would otherwise stick for global hotkeys).
+    React.useEffect(() => {
+        if (isHoverPinned) {
+            hoverPinnedItemIdRef.current = item.id;
+            hoveredItemIdRef.current = item.id;
+            return;
+        }
+        if (hoverPinnedItemIdRef.current !== item.id) {
+            return;
+        }
+        hoverPinnedItemIdRef.current = null;
+        if (
+            !isPointerOverCardRef.current &&
+            hoveredItemIdRef.current === item.id
+        ) {
+            hoveredItemIdRef.current = null;
+        }
+    }, [hoveredItemIdRef, hoverPinnedItemIdRef, isHoverPinned, item.id]);
 
     const handleZoomChange = useStableCallback((nextZoomed: boolean) => {
         if (!nextZoomed) {
@@ -4697,8 +4673,6 @@ function MediaCard({ item }: LibraryGridCardProps) {
             markVisited(item.id);
         }
     };
-
-    const isPickerOpen = openPickerItemId === item.id;
 
     const handlePickerOpenChange = useStableCallback((nextOpen: boolean) => {
         setOpenPickerItemId(nextOpen ? item.id : null);
@@ -4720,11 +4694,17 @@ function MediaCard({ item }: LibraryGridCardProps) {
     );
 
     const handleMouseEnter = useStableCallback(() => {
+        isPointerOverCardRef.current = true;
+        const pinnedId = hoverPinnedItemIdRef.current;
+        if (pinnedId !== null && pinnedId !== item.id) {
+            return;
+        }
         hoveredItemIdRef.current = item.id;
     });
 
     const handleMouseLeave = useStableCallback(() => {
-        if (hoveredItemIdRef.current === item.id) {
+        isPointerOverCardRef.current = false;
+        if (hoveredItemIdRef.current === item.id && !isHoverPinned) {
             hoveredItemIdRef.current = null;
         }
     });
@@ -4754,14 +4734,14 @@ function MediaCard({ item }: LibraryGridCardProps) {
                 {/* biome-ignore lint/a11y/useSemanticElements: ControlledZoom conflicts with anchor elements */}
                 <div
                     aria-label={displayTitle}
-                    className="squircle flex flex-col overflow-clip rounded-xl focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                    className="squircle relative flex flex-col overflow-clip rounded-xl focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
                     onClick={handlePrimaryClick}
                     onKeyDown={handlePrimaryKeyDown}
                     role="link"
                     tabIndex={0}
                 >
                     {isNote ? (
-                        <div className="relative flex h-auto min-h-56 w-full flex-col justify-between bg-linear-to-br from-amber-50 via-background to-stone-100 p-3">
+                        <div className="relative flex h-auto min-h-56 w-full flex-col justify-between bg-linear-to-br from-note-surface-from via-background to-note-surface-to p-3">
                             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(251,191,36,0.18),transparent_45%)]" />
                             <div className="relative flex flex-1 flex-col gap-2 pt-1.5">
                                 <p className="whitespace-pre-wrap text-[11px] text-foreground leading-relaxed opacity-90">
@@ -4782,7 +4762,7 @@ function MediaCard({ item }: LibraryGridCardProps) {
                                 />
                             </ControlledZoom>
                             {isLastVisited(item.id) ? (
-                                <span className="absolute top-2 right-2 z-10 inline-flex items-center gap-1 rounded-full bg-black/45 px-1.5 py-px font-medium text-white text-xs leading-normal backdrop-blur-sm">
+                                <span className="absolute right-2 bottom-2 z-10 inline-flex items-center gap-1 rounded-full bg-black/45 px-1.5 py-px font-medium text-white text-xs leading-normal">
                                     <T>Last visited</T>
                                     <ArrowUpRight
                                         aria-hidden
@@ -4791,7 +4771,7 @@ function MediaCard({ item }: LibraryGridCardProps) {
                                     />
                                 </span>
                             ) : (
-                                <span className="absolute top-2 right-2 z-10 rounded-full bg-black/50 px-1.5 py-px font-medium text-white text-xs leading-normal opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100">
+                                <span className="absolute right-2 bottom-2 z-10 rounded-full bg-black/50 px-1.5 py-px font-medium text-white text-xs leading-normal opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100">
                                     <ArrowUpRight
                                         aria-hidden
                                         className="size-4"
@@ -4831,10 +4811,8 @@ function MediaCard({ item }: LibraryGridCardProps) {
                                 createdLabel={createdLabel}
                                 href={href}
                                 isDownloading={isDownloading}
-                                isOpen={isCardMenuOpen}
                                 item={item}
                                 kind="menu"
-                                onClose={closeCardMenu}
                                 onDownload={handleDownload}
                                 onZoomIn={handleZoomIn}
                                 previewImageUrl={previewImageUrl}
@@ -4849,10 +4827,8 @@ function MediaCard({ item }: LibraryGridCardProps) {
                     createdLabel={createdLabel}
                     href={href}
                     isDownloading={isDownloading}
-                    isOpen={isContextMenuOpen}
                     item={item}
                     kind="context"
-                    onClose={closeContextMenu}
                     onDownload={handleDownload}
                     onZoomIn={handleZoomIn}
                     previewImageUrl={previewImageUrl}
@@ -4912,7 +4888,7 @@ function LockedPreviewCard({
     return (
         <div className="relative flex flex-col overflow-clip rounded-xl ring-1 ring-border/30">
             {data.kind === "note" ? (
-                <div className="relative min-h-56 bg-linear-to-br from-amber-50 via-background to-stone-100 p-4">
+                <div className="relative min-h-56 bg-linear-to-br from-note-surface-from via-background to-note-surface-to p-4">
                     <div className="absolute inset-0 bg-background/30" />
                     <div className="relative flex h-full flex-col gap-3">
                         <div className="space-y-2">
@@ -5348,6 +5324,107 @@ function CreateResultsCollectionDialog({
     );
 }
 
+/**
+ * Card action shortcuts that target the hovered grid card (via
+ * `hoveredItemIdRef`), matching the collections-list hover-hotkey pattern
+ * and the `S` collection-picker shortcut. Registered once at the browser
+ * root so every card does not mount its own `useHotkeys` listeners.
+ */
+function useCardHoverHotkeys(input: {
+    hoveredItemIdRef: React.RefObject<string | null>;
+    itemsRef: React.RefObject<LibraryItemWithCollections[]>;
+    onDelete: (item: LibraryItemWithCollections) => void;
+    onItemFavoriteToggle: (item: LibraryItemWithCollections) => void;
+    pendingDeleteItemIdRef: React.RefObject<string | null>;
+}) {
+    const {
+        hoveredItemIdRef,
+        itemsRef,
+        onDelete,
+        onItemFavoriteToggle,
+        pendingDeleteItemIdRef,
+    } = input;
+    const quickLookTriggerId = React.useId();
+
+    const resolveHoveredItem = useStableCallback(() => {
+        // Collection rows claim the surface while hovered so pinned card
+        // menus do not steal Alt+E / Alt+F / ⌘⌫ from collection shortcuts.
+        if (isHoverHotkeySurface("collection")) {
+            return null;
+        }
+        const id = hoveredItemIdRef.current;
+        if (!id || pendingDeleteItemIdRef.current === id) {
+            return null;
+        }
+        return itemsRef.current.find((item) => item.id === id) ?? null;
+    });
+
+    useHotkeys(
+        "alt+f",
+        (event: KeyboardEvent) => {
+            const item = resolveHoveredItem();
+            if (!item) {
+                return;
+            }
+            event.preventDefault();
+            onItemFavoriteToggle(item);
+        },
+        {
+            description: "Toggle favorite on hovered item",
+            enableOnContentEditable: false,
+            enableOnFormTags: false,
+        },
+        [onItemFavoriteToggle, resolveHoveredItem]
+    );
+
+    useHotkeys(
+        "alt+e",
+        (event: KeyboardEvent) => {
+            const item = resolveHoveredItem();
+            if (!item || item.kind === ITEM_KIND_NOTE) {
+                return;
+            }
+            const href = normalizeURL(item.url);
+            if (toValidUrl(href) === FALLBACK_URL) {
+                return;
+            }
+            event.preventDefault();
+            openQuickLookDrawer(
+                {
+                    description: itemDomain(item.url),
+                    title: getItemTitle(item),
+                    url: item.url,
+                },
+                quickLookTriggerId
+            );
+        },
+        {
+            description: "Quick look on hovered item",
+            enableOnContentEditable: false,
+            enableOnFormTags: false,
+        },
+        [quickLookTriggerId, resolveHoveredItem]
+    );
+
+    useHotkeys(
+        "mod+backspace",
+        (event: KeyboardEvent) => {
+            const item = resolveHoveredItem();
+            if (!item) {
+                return;
+            }
+            event.preventDefault();
+            onDelete(item);
+        },
+        {
+            description: "Delete hovered item",
+            enableOnContentEditable: false,
+            enableOnFormTags: false,
+        },
+        [onDelete, resolveHoveredItem]
+    );
+}
+
 export function BrowserRoot({
     connectedIntegrationCount,
     lockedItemCount,
@@ -5407,8 +5484,8 @@ export function BrowserRoot({
     const [unreachableFilterEnabled, setUnreachableFilterEnabled] =
         React.useState(false);
     const [unreachableProbe, setUnreachableProbe] = React.useState({
-        active: false,
         checked: 0,
+        isActive: false,
         total: 0,
     });
     const unreachableProbeVersionRef = React.useRef(0);
@@ -5429,6 +5506,7 @@ export function BrowserRoot({
         string | null
     >(null);
     const hoveredItemIdRef = React.useRef<string | null>(null);
+    const hoverPinnedItemIdRef = React.useRef<string | null>(null);
 
     const [isCreateResultsDialogOpen, setIsCreateResultsDialogOpen] =
         React.useState(false);
@@ -5467,6 +5545,10 @@ export function BrowserRoot({
         },
         setVisibleItems: onItemsChange,
     });
+    const pendingDeleteItemIdRef = React.useRef<string | null>(
+        pendingDeleteItem?.id ?? null
+    );
+    pendingDeleteItemIdRef.current = pendingDeleteItem?.id ?? null;
 
     const [isSavingNote, startSavingNoteTransition] = React.useTransition();
     const [isSavingPastedUrl, startSavingPastedUrlTransition] =
@@ -5541,7 +5623,7 @@ export function BrowserRoot({
     React.useEffect(() => {
         if (!unreachableFilterEnabled) {
             unreachableProbeVersionRef.current += 1;
-            setUnreachableProbe({ active: false, checked: 0, total: 0 });
+            setUnreachableProbe({ checked: 0, isActive: false, total: 0 });
             return;
         }
 
@@ -5573,8 +5655,8 @@ export function BrowserRoot({
 
                 if (candidates.length === 0) {
                     setUnreachableProbe({
-                        active: false,
                         checked: totalProbeable,
+                        isActive: false,
                         total: totalProbeable,
                     });
                     // Library may still be hydrating; keep waiting while empty.
@@ -5586,8 +5668,8 @@ export function BrowserRoot({
                 }
 
                 setUnreachableProbe({
-                    active: true,
                     checked,
+                    isActive: true,
                     total: totalProbeable,
                 });
 
@@ -5610,8 +5692,8 @@ export function BrowserRoot({
 
                     if (result.rateLimited) {
                         setUnreachableProbe({
-                            active: true,
                             checked,
+                            isActive: true,
                             total: totalProbeable,
                         });
                         await sleep(Math.max(1000, result.retryAfterMs));
@@ -5741,7 +5823,7 @@ export function BrowserRoot({
             if (patch.columnCountMode) {
                 setColumnCountMode(patch.columnCountMode);
             }
-            if (patch.selectedCollectionIds) {
+            if (patch.selectedCollectionIds !== undefined) {
                 onClearCollectionFilters();
                 for (const collectionId of patch.selectedCollectionIds) {
                     onRemoveCollectionFilter(collectionId);
@@ -6031,7 +6113,7 @@ export function BrowserRoot({
         items.length === 0 && filteredItems.length === 0 && !hasActiveFilters;
 
     const isUnreachableProbePending =
-        unreachableFilterEnabled && unreachableProbe.active;
+        unreachableFilterEnabled && unreachableProbe.isActive;
 
     const shouldShowNoFilteredResults =
         filteredItems.length === 0 &&
@@ -6071,10 +6153,10 @@ export function BrowserRoot({
     }
     if (unreachableFilterEnabled && unreachableProbe.total > 0) {
         const remaining = unreachableProbe.total - unreachableProbe.checked;
-        let progressLabel = unreachableProbe.active
+        let progressLabel = unreachableProbe.isActive
             ? `Checking links ${unreachableProbe.checked}/${unreachableProbe.total}`
             : `Checked ${unreachableProbe.checked} link${unreachableProbe.checked === 1 ? "" : "s"}`;
-        if (unreachableProbe.active && remaining > 0) {
+        if (unreachableProbe.isActive && remaining > 0) {
             // Server budget is 100 probes/minute; give a coarse ETA.
             const minutesLeft = Math.max(1, Math.ceil(remaining / 100));
             progressLabel = `${progressLabel} · ~${minutesLeft} min left`;
@@ -6276,6 +6358,9 @@ export function BrowserRoot({
         }
 
         if (event.key.toLowerCase() === "s") {
+            if (isHoverHotkeySurface("collection")) {
+                return;
+            }
             const id = hoveredItemIdRef.current;
             if (id) {
                 event.preventDefault();
@@ -6510,6 +6595,14 @@ export function BrowserRoot({
             });
         }
     );
+
+    useCardHoverHotkeys({
+        hoveredItemIdRef,
+        itemsRef,
+        onDelete: handleRequestDelete,
+        onItemFavoriteToggle: handleItemFavoriteToggle,
+        pendingDeleteItemIdRef,
+    });
 
     const handleFindSimilar = useStableCallback(
         (item: LibraryItemWithCollections) => {
@@ -6747,9 +6840,9 @@ export function BrowserRoot({
                     sectionsLength={sections.length}
                 >
                     <ComposerActionNew />
-                    <ComposerActionRemoveDuplicates />
                     <ComposerActionMetrics />
                     <ComposerActionOnboarding />
+                    <ComposerActionRemoveDuplicates />
                 </ComposerActions>
             </Composer>
             <ComposerSuggestionsList
@@ -6784,6 +6877,7 @@ export function BrowserRoot({
                 enableSectionCollapse={enableSectionCollapse}
                 favoriteItemIdSet={favoriteItemIdSet}
                 hoveredItemIdRef={hoveredItemIdRef}
+                hoverPinnedItemIdRef={hoverPinnedItemIdRef}
                 onCollapseAllSections={collapseAllSections}
                 onCopyLink={handleCopyLink}
                 onCreateCollectionFromResults={handleOpenCreateResultsDialog}

--- a/components/library/browser.tsx
+++ b/components/library/browser.tsx
@@ -19,7 +19,7 @@ import {
     type CommandSuggestion,
     type PaletteStackEntry,
 } from "@/components/library/composer";
-import { isHoverHotkeySurface } from "@/components/library/hover-hotkey-surface";
+import { isCollectionHoverHotkeySurface } from "@/components/library/hover-hotkey-surface";
 import {
     NoteEditor,
     NoteHeader,
@@ -5349,7 +5349,7 @@ function useCardHoverHotkeys(input: {
     const resolveHoveredItem = useStableCallback(() => {
         // Collection rows claim the surface while hovered so pinned card
         // menus do not steal Alt+E / Alt+F / ⌘⌫ from collection shortcuts.
-        if (isHoverHotkeySurface("collection")) {
+        if (isCollectionHoverHotkeySurface()) {
             return null;
         }
         const id = hoveredItemIdRef.current;
@@ -6358,7 +6358,7 @@ export function BrowserRoot({
         }
 
         if (event.key.toLowerCase() === "s") {
-            if (isHoverHotkeySurface("collection")) {
+            if (isCollectionHoverHotkeySurface()) {
                 return;
             }
             const id = hoveredItemIdRef.current;

--- a/components/library/collections.tsx
+++ b/components/library/collections.tsx
@@ -2,8 +2,10 @@
 
 import { useSubscriptionAccess } from "@/components/billing/subscription";
 import {
-    claimHoverHotkeySurface,
-    releaseHoverHotkeySurface,
+    claimCollectionHoverHotkeySurface,
+    clearCollectionHoverHotkeySurface,
+    isCollectionHoverHotkeySurface,
+    releaseCollectionHoverHotkeySurface,
 } from "@/components/library/hover-hotkey-surface";
 import {
     appendCollection,
@@ -953,7 +955,7 @@ function useCollectionSync(
     const syncDeleted = useStableCallback((collectionId: string) => {
         if (hoveredCollectionRef.current?.id === collectionId) {
             hoveredCollectionRef.current = null;
-            releaseHoverHotkeySurface("collection");
+            clearCollectionHoverHotkeySurface();
         }
         setCollections((current) =>
             current.filter((collection) => collection.id !== collectionId)
@@ -1427,10 +1429,17 @@ function useCollectionHoverHotkeys(input: {
         setPendingPriorityComboboxCollectionId,
     } = input;
 
+    const resolveHoveredCollection = () => {
+        if (!isCollectionHoverHotkeySurface()) {
+            return null;
+        }
+        return hoveredCollectionRef.current;
+    };
+
     useHotkeys(
         "alt+e",
         (event) => {
-            const target = hoveredCollectionRef.current;
+            const target = resolveHoveredCollection();
             if (target) {
                 event.preventDefault();
                 requestRename(target);
@@ -1442,7 +1451,7 @@ function useCollectionHoverHotkeys(input: {
     useHotkeys(
         ["delete", "backspace"],
         (event) => {
-            const target = hoveredCollectionRef.current;
+            const target = resolveHoveredCollection();
             if (target) {
                 event.preventDefault();
                 requestDelete(target);
@@ -1454,7 +1463,7 @@ function useCollectionHoverHotkeys(input: {
     useHotkeys(
         "c",
         (event) => {
-            const target = hoveredCollectionRef.current;
+            const target = resolveHoveredCollection();
             if (target && target.itemCount > 0) {
                 event.preventDefault();
                 onCopyLinks(target);
@@ -1466,7 +1475,7 @@ function useCollectionHoverHotkeys(input: {
     useHotkeys(
         "alt+f",
         (event) => {
-            const target = hoveredCollectionRef.current;
+            const target = resolveHoveredCollection();
             if (target && !favoriteCollectionIdSetRef.current.has(target.id)) {
                 event.preventDefault();
                 toggleFavorite(target);
@@ -1478,7 +1487,7 @@ function useCollectionHoverHotkeys(input: {
     useHotkeys(
         "p",
         () => {
-            const target = hoveredCollectionRef.current;
+            const target = resolveHoveredCollection();
             if (!target) {
                 return;
             }
@@ -1500,6 +1509,27 @@ function useCollectionsController() {
     const dialogs = useCollectionDialogRequests();
     const rowActions = useCollectionRowActions(sync);
     const selectedCollectionIdSet = new Set(selectedCollectionIds);
+
+    React.useEffect(() => {
+        const clearStaleCollectionHover = () => {
+            hoveredCollectionRef.current = null;
+            clearCollectionHoverHotkeySurface();
+        };
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === "hidden") {
+                clearStaleCollectionHover();
+            }
+        };
+        window.addEventListener("blur", clearStaleCollectionHover);
+        document.addEventListener("visibilitychange", handleVisibilityChange);
+        return () => {
+            window.removeEventListener("blur", clearStaleCollectionHover);
+            document.removeEventListener(
+                "visibilitychange",
+                handleVisibilityChange
+            );
+        };
+    }, []);
 
     useCollectionPanelHotkeys();
     useCollectionHoverHotkeys({
@@ -2942,33 +2972,31 @@ function CollectionsListItem({
         useCollectionsState();
     const handleMouseEnter = useStableCallback(onMouseEnterProp);
     const handleMouseLeave = useStableCallback(onMouseLeaveProp);
+    const hoverClaimIdRef = React.useRef(0);
     const isSelected = selectedCollectionIdSet.has(collection.id);
     const style = getCollectionItemStyle(collection.name, isSelected);
 
-    React.useEffect(
-        () => () => {
-            if (hoveredCollectionRef.current?.id === collection.id) {
-                hoveredCollectionRef.current = null;
-                releaseHoverHotkeySurface("collection");
-            }
-        },
-        [collection.id, hoveredCollectionRef]
-    );
+    const releaseHoverClaim = useStableCallback(() => {
+        releaseCollectionHoverHotkeySurface(hoverClaimIdRef.current);
+        hoverClaimIdRef.current = 0;
+        if (hoveredCollectionRef.current?.id === collection.id) {
+            hoveredCollectionRef.current = null;
+        }
+    });
+
+    React.useEffect(() => releaseHoverClaim, [releaseHoverClaim]);
 
     const onMouseEnter = useStableCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {
             hoveredCollectionRef.current = collection;
-            claimHoverHotkeySurface("collection");
+            hoverClaimIdRef.current = claimCollectionHoverHotkeySurface();
             handleMouseEnter?.(event);
         }
     );
 
     const onMouseLeave = useStableCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {
-            if (hoveredCollectionRef.current?.id === collection.id) {
-                hoveredCollectionRef.current = null;
-                releaseHoverHotkeySurface("collection");
-            }
+            releaseHoverClaim();
             handleMouseLeave?.(event);
         }
     );

--- a/components/library/collections.tsx
+++ b/components/library/collections.tsx
@@ -2,6 +2,10 @@
 
 import { useSubscriptionAccess } from "@/components/billing/subscription";
 import {
+    claimHoverHotkeySurface,
+    releaseHoverHotkeySurface,
+} from "@/components/library/hover-hotkey-surface";
+import {
     appendCollection,
     mergeCollectionSummaries,
     replaceCollectionShareState,
@@ -146,7 +150,6 @@ import EmptyCollectionStateImage from "@/public/empty-collection-state.png";
 import SmartCollectionsBackgroundImg from "@/public/smart-collections-background-wide.webp";
 import type { BaseUIEvent } from "@base-ui/react";
 import { Toolbar } from "@base-ui/react/toolbar";
-import { useAnimationFrame } from "@base-ui/utils/useAnimationFrame";
 import { useIsoLayoutEffect } from "@base-ui/utils/useIsoLayoutEffect";
 import { useStableCallback } from "@base-ui/utils/useStableCallback";
 import { useTimeout } from "@base-ui/utils/useTimeout";
@@ -165,7 +168,9 @@ import {
     ExternalLinkIcon,
     FileSpreadsheetIcon,
     Globe,
+    GlobeCheck,
     Info,
+    LayoutList,
     LibraryBig,
     Lightbulb,
     LinkIcon,
@@ -528,17 +533,77 @@ const SORT_OPTION_BY_VALUE = new Map(
 );
 
 const VIEW_OPTIONS = [
-    { icon: ArchiveIcon, label: "Show all", value: "show-all" },
+    { icon: LayoutList, label: "Show all", value: "show-all" },
     { icon: ArchiveX, label: "Exclude archives", value: "exclude-archives" },
-    { icon: Globe, label: "Show shared only", value: "show-shared-only" },
+    { icon: GlobeCheck, label: "Show shared only", value: "show-shared-only" },
 ] as const;
 
 const { useStore: useCollectionsListStateStore } = createStore({
     favoriteCollectionIds: storage<string[]>([]),
+    feedback: null as CollectionFeedback | null,
     isCollectionsListOpen: storage(false),
     isFavoritesListOpen: storage(true),
     isRecommendationsOpen: storage(true),
 });
+
+function getFavoriteCollectionSummaries(
+    collectionSummaries: LibraryCollectionSummary[],
+    favoriteCollectionIds: readonly string[]
+): LibraryCollectionSummary[] {
+    if (favoriteCollectionIds.length === 0) {
+        return [];
+    }
+    const favoriteCollectionIdSet = new Set(favoriteCollectionIds);
+    return collectionSummaries.filter((collection) =>
+        favoriteCollectionIdSet.has(collection.id)
+    );
+}
+
+function useCollectionFeedbackWriter() {
+    const { setFeedback } = useCollectionsListStateStore();
+
+    const showError = useStableCallback((message: string) => {
+        setFeedback({ message, tone: "error" });
+    });
+    const showSuccess = useStableCallback((message: string) => {
+        setFeedback({ message, tone: "success" });
+    });
+
+    return { showError, showSuccess };
+}
+
+function useCollectionFeedback() {
+    const { feedback, setFeedback } = useCollectionsListStateStore();
+    const dismissFeedback = useStableCallback(() => {
+        setFeedback(null);
+    });
+
+    return { dismissFeedback, feedback };
+}
+
+function useToggleCollectionFavorite() {
+    const { favoriteCollectionIds, setFavoriteCollectionIds, setFeedback } =
+        useCollectionsListStateStore();
+    const favoriteCollectionIdSet = new Set(favoriteCollectionIds);
+
+    const toggleFavorite = useStableCallback(
+        (collection: LibraryCollectionSummary) => {
+            let isNowFavorite = false;
+            setFavoriteCollectionIds((current) => {
+                isNowFavorite = !current.includes(collection.id);
+                return toggleValue(current, collection.id);
+            });
+            setFeedback({
+                message: isNowFavorite
+                    ? `${collection.name} added to Favorites.`
+                    : `${collection.name} removed from Favorites.`,
+                tone: "success",
+            });
+        }
+    );
+
+    return { favoriteCollectionIdSet, toggleFavorite };
+}
 
 const CollectionsListItemContext =
     React.createContext<CollectionsListItemContextValue | null>(null);
@@ -826,136 +891,11 @@ function CollectionThumbnailCell({ url }: { url: string | null }) {
     );
 }
 
-function useCollectionsController() {
-    const {
-        collectionPreviewThumbnailUrlsById,
-        collections,
-        collectionSummaries,
-        favoriteItemIdSet,
-        favoriteItems,
-        itemsByCollectionId,
-        onClearCollectionFilters,
-        onOpenFavoriteItem,
-        onSelectCollection,
-        onToggleItemFavorite,
-        selectedCollectionIds,
-        setCollections,
-        setItems,
-    } = useWorkspaceContext();
-
-    const { hasAccess } = useSubscriptionAccess();
-
-    const {
-        favoriteCollectionIds,
-        isCollectionsListOpen,
-        isFavoritesListOpen,
-        isRecommendationsOpen,
-        setFavoriteCollectionIds,
-        setIsCollectionsListOpen,
-        setIsFavoritesListOpen,
-        setIsRecommendationsOpen,
-    } = useCollectionsListStateStore();
-
-    const {
-        collectionSortField,
-        collectionTextMatchQuery,
-        setCollectionSortField,
-        setCollectionTextMatchQuery,
-        setCollectionView,
-        collectionView,
-    } = useCollectionsSortStore();
-
-    const { copyToClipboard } = useCopyToClipboard();
-    const [, startTransition] = React.useTransition();
-
-    const [isCreateOpen, setIsCreateOpen] = React.useState(false);
-    const [createItemId, setCreateItemId] = React.useState<string | null>(null);
-    const createSubmissionPendingRef = React.useRef(false);
-
-    const [pendingRename, setPendingRename] =
-        React.useState<LibraryCollectionSummary | null>(null);
-
-    const [pendingDelete, setPendingDelete] =
-        React.useState<LibraryCollectionSummary | null>(null);
-
-    const [pendingShareIds, setPendingShareIds] = React.useState<string[]>([]);
-    const [pendingNotionCollectionIds, setPendingNotionCollectionIds] =
-        React.useState<string[]>([]);
-
-    const [isSortOpen, setIsSortOpen] = React.useState(false);
-    const [sortInputValue, setSortInputValue] = React.useState("");
-
-    const [
-        pendingPriorityComboboxCollectionId,
-        setPendingPriorityComboboxCollectionId,
-    ] = React.useState<string | null>(null);
-
-    const [feedback, setFeedback] = React.useState<CollectionFeedback | null>(
-        null
-    );
-
-    const pendingActionIdsRef = React.useRef(new Set<string>());
-    const favoriteCollectionIdSetRef = React.useRef(new Set<string>());
-    const hoveredCollectionRef = React.useRef<LibraryCollectionSummary | null>(
-        null
-    );
-
-    const hasAnySelected = selectedCollectionIds.length > 0;
-    const selectedCollectionIdSet = new Set(selectedCollectionIds);
-    const pendingShareIdSet = new Set(pendingShareIds);
-    const pendingNotionCollectionIdSet = new Set(pendingNotionCollectionIds);
-    const collectionLabels = collectionSummaries.map(
-        (collection) => collection.name
-    );
-    const favoriteCollectionIdSet = new Set(favoriteCollectionIds);
-    favoriteCollectionIdSetRef.current = favoriteCollectionIdSet;
-    const favoriteCollectionSummaries = collectionSummaries.filter(
-        (collection) => favoriteCollectionIdSet.has(collection.id)
-    );
-    const currentSortOption =
-        collectionSortField === "text-match"
-            ? {
-                  icon: ListFilter,
-                  label: `Sort by "${collectionTextMatchQuery}"`,
-              }
-            : (SORT_OPTION_BY_VALUE.get(collectionSortField) ?? null);
-    const comboboxValue: ComboboxValue = {
-        icon: currentSortOption?.icon ?? ListFilter,
-        label: currentSortOption?.label ?? "Priority",
-        sortField: collectionSortField,
-        sortQuery: collectionTextMatchQuery,
-        view: collectionView,
-    };
-
-    const showError = useStableCallback((message: string) =>
-        setFeedback({ message, tone: "error" })
-    );
-    const showSuccess = useStableCallback((message: string) =>
-        setFeedback({ message, tone: "success" })
-    );
-
-    const getCollectionItems = (collectionId: string) =>
-        itemsByCollectionId.get(collectionId) ?? [];
-
-    const hasHiddenItems = (collection: LibraryCollectionSummary) =>
-        !hasAccess &&
-        getCollectionItems(collection.id).length < collection.itemCount;
-
-    const ensureAccess = (
-        collection: LibraryCollectionSummary,
-        action: string
-    ) => {
-        if (!hasHiddenItems(collection)) {
-            return true;
-        }
-        showError(`Upgrade to ${action} every item in ${collection.name}.`);
-        return false;
-    };
-
-    const setCollectionSharePending = useTogglePendingId(setPendingShareIds);
-    const setCollectionNotionPending = useTogglePendingId(
-        setPendingNotionCollectionIds
-    );
+function useCollectionSync(
+    hoveredCollectionRef: React.RefObject<LibraryCollectionSummary | null>
+) {
+    const { setCollections, setItems } = useWorkspaceContext();
+    const { setFavoriteCollectionIds } = useCollectionsListStateStore();
 
     const syncItemTags = useStableCallback(
         (updater: (tags: LibraryCollectionTag[]) => LibraryCollectionTag[]) => {
@@ -963,26 +903,28 @@ function useCollectionsController() {
         }
     );
 
-    const syncShare = (next: CollectionShareState) => {
+    const syncShare = useStableCallback((next: CollectionShareState) => {
         setCollections((current) =>
             sortCollections(replaceCollectionShareState(current, next))
         );
         syncItemTags((tags) => replaceCollectionShareState(tags, next));
-    };
+    });
 
-    const syncPriority = (id: string, priority: CollectionPriority) => {
-        setCollections((current) =>
-            sortCollections(
-                updateById(current, id, (collection) => ({
-                    ...collection,
-                    priority,
-                }))
-            )
-        );
-        syncItemTags((tags) =>
-            updateById(tags, id, (tag) => ({ ...tag, priority }))
-        );
-    };
+    const syncPriority = useStableCallback(
+        (id: string, priority: CollectionPriority) => {
+            setCollections((current) =>
+                sortCollections(
+                    updateById(current, id, (collection) => ({
+                        ...collection,
+                        priority,
+                    }))
+                )
+            );
+            syncItemTags((tags) =>
+                updateById(tags, id, (tag) => ({ ...tag, priority }))
+            );
+        }
+    );
 
     const syncName = useStableCallback((id: string, name: string) => {
         setCollections((current) => replaceName(current, id, name));
@@ -1012,6 +954,7 @@ function useCollectionsController() {
     const syncDeleted = useStableCallback((collectionId: string) => {
         if (hoveredCollectionRef.current?.id === collectionId) {
             hoveredCollectionRef.current = null;
+            releaseHoverHotkeySurface("collection");
         }
         setCollections((current) =>
             current.filter((collection) => collection.id !== collectionId)
@@ -1022,56 +965,30 @@ function useCollectionsController() {
         );
     });
 
+    return {
+        syncCreated,
+        syncDeleted,
+        syncName,
+        syncPriority,
+        syncShare,
+    };
+}
+
+function useCollectionDialogRequests() {
+    const { setFeedback } = useCollectionsListStateStore();
+
+    const [isCreateOpen, setIsCreateOpen] = React.useState(false);
+    const [createItemId, setCreateItemId] = React.useState<string | null>(null);
+    const createSubmissionPendingRef = React.useRef(false);
+
+    const [pendingRename, setPendingRename] =
+        React.useState<LibraryCollectionSummary | null>(null);
+    const [pendingDelete, setPendingDelete] =
+        React.useState<LibraryCollectionSummary | null>(null);
+
     const requestCreate = useStableCallback((itemId?: string) => {
         setCreateItemId(itemId ?? null);
         setIsCreateOpen(true);
-    });
-
-    const handleCreateShortcutPress = useStableCallback(() => {
-        if (isCreateOpen) {
-            if (createSubmissionPendingRef.current) {
-                return;
-            }
-            setIsCreateOpen(false);
-            return;
-        }
-        requestCreate();
-    });
-
-    const handleCollectionsListShortcutPress = useStableCallback(() => {
-        setIsCollectionsListOpen((current) => !current);
-    });
-
-    const handleFavoritesListShortcutPress = useStableCallback(() => {
-        setIsFavoritesListOpen((current) => !current);
-    });
-
-    const handleSortShortcutPress = useStableCallback(
-        (event: KeyboardEvent) => {
-            event.preventDefault();
-            setIsCollectionsListOpen(true);
-            setIsSortOpen(true);
-        }
-    );
-
-    useHotkeys("mod+n", handleCreateShortcutPress, {
-        description: "Create a new collection",
-        preventDefault: true,
-    });
-
-    useHotkeys("mod+c", handleCollectionsListShortcutPress, {
-        description: "Toggle collections panel",
-    });
-
-    useHotkeys("shift+mod+f", handleFavoritesListShortcutPress, {
-        description: "Toggle favorites panel",
-        preventDefault: true,
-    });
-
-    useHotkeys("mod+f", handleSortShortcutPress, {
-        description: "Sort and organize collections",
-        enabled: !isSortOpen,
-        preventDefault: true,
     });
 
     const requestDelete = useStableCallback(
@@ -1088,6 +1005,79 @@ function useCollectionsController() {
         }
     );
 
+    const handleCreateShortcutPress = useStableCallback(() => {
+        if (isCreateOpen) {
+            if (createSubmissionPendingRef.current) {
+                return;
+            }
+            setIsCreateOpen(false);
+            return;
+        }
+        requestCreate();
+    });
+
+    useHotkeys("mod+n", handleCreateShortcutPress, {
+        description: "Create a new collection",
+        preventDefault: true,
+    });
+
+    return {
+        createItemId,
+        createSubmissionPendingRef,
+        isCreateOpen,
+        pendingDelete,
+        pendingRename,
+        requestCreate,
+        requestDelete,
+        requestRename,
+        setIsCreateOpen,
+        setPendingDelete,
+        setPendingRename,
+    };
+}
+
+function useCollectionRowActions(sync: ReturnType<typeof useCollectionSync>) {
+    const { collections, itemsByCollectionId } = useWorkspaceContext();
+    const { hasAccess } = useSubscriptionAccess();
+    const { setFeedback } = useCollectionsListStateStore();
+    const { showError, showSuccess } = useCollectionFeedbackWriter();
+    const { copyToClipboard } = useCopyToClipboard();
+    const [, startTransition] = React.useTransition();
+
+    const [pendingShareIds, setPendingShareIds] = React.useState<string[]>([]);
+    const [pendingNotionCollectionIds, setPendingNotionCollectionIds] =
+        React.useState<string[]>([]);
+    const [
+        pendingPriorityComboboxCollectionId,
+        setPendingPriorityComboboxCollectionId,
+    ] = React.useState<string | null>(null);
+
+    const pendingActionIdsRef = React.useRef(new Set<string>());
+    const pendingShareIdSet = new Set(pendingShareIds);
+    const pendingNotionCollectionIdSet = new Set(pendingNotionCollectionIds);
+
+    const setCollectionSharePending = useTogglePendingId(setPendingShareIds);
+    const setCollectionNotionPending = useTogglePendingId(
+        setPendingNotionCollectionIds
+    );
+
+    const getCollectionItems = (collectionId: string) =>
+        itemsByCollectionId.get(collectionId) ?? [];
+
+    const ensureAccess = (
+        collection: LibraryCollectionSummary,
+        action: string
+    ) => {
+        const isHidden =
+            !hasAccess &&
+            getCollectionItems(collection.id).length < collection.itemCount;
+        if (!isHidden) {
+            return true;
+        }
+        showError(`Upgrade to ${action} every item in ${collection.name}.`);
+        return false;
+    };
+
     const copyWithFeedback = async (
         text: string,
         success: string,
@@ -1099,54 +1089,6 @@ function useCollectionsController() {
             showError(error);
         }
     };
-
-    const handleCopyLinks = useStableCallback(
-        async (collection: LibraryCollectionSummary) => {
-            if (!ensureAccess(collection, "copy")) {
-                return;
-            }
-
-            const items = getCollectionItems(collection.id);
-            const urls = getItemUrls(items);
-
-            if (urls.length === 0) {
-                showError(EMPTY_LINKS_ERROR_MESSAGE);
-                return;
-            }
-
-            await copyWithFeedback(
-                urls.join("\n"),
-                `Links from ${collection.name} copied to the clipboard.`,
-                COPY_LINKS_ERROR_MESSAGE
-            );
-        }
-    );
-
-    const handleCopyTitle = useStableCallback(
-        async (collection: LibraryCollectionSummary) => {
-            await copyWithFeedback(
-                collection.name,
-                `${collection.name} title copied to the clipboard.`,
-                COPY_TITLE_ERROR_MESSAGE
-            );
-        }
-    );
-
-    const handleCopyShareLink = useStableCallback(
-        async (collection: LibraryCollectionSummary) => {
-            if (!collection.shareId) {
-                showError(COPY_SHARE_LINK_MISSING_MESSAGE);
-                return;
-            }
-
-            const url = buildPublicCollectionShareUrl(collection.shareId);
-            await copyWithFeedback(
-                url,
-                `Public link for ${collection.name} copied to the clipboard.`,
-                COPY_SHARE_LINK_ERROR_MESSAGE
-            );
-        }
-    );
 
     const runGuardedAction = useStableCallback(
         <T,>(config: {
@@ -1183,7 +1125,52 @@ function useCollectionsController() {
         }
     );
 
-    const handleEnableShare = useStableCallback(
+    const onCopyLinks = useStableCallback(
+        async (collection: LibraryCollectionSummary) => {
+            if (!ensureAccess(collection, "copy")) {
+                return;
+            }
+
+            const urls = getItemUrls(getCollectionItems(collection.id));
+            if (urls.length === 0) {
+                showError(EMPTY_LINKS_ERROR_MESSAGE);
+                return;
+            }
+
+            await copyWithFeedback(
+                urls.join("\n"),
+                `Links from ${collection.name} copied to the clipboard.`,
+                COPY_LINKS_ERROR_MESSAGE
+            );
+        }
+    );
+
+    const onCopyTitle = useStableCallback(
+        async (collection: LibraryCollectionSummary) => {
+            await copyWithFeedback(
+                collection.name,
+                `${collection.name} title copied to the clipboard.`,
+                COPY_TITLE_ERROR_MESSAGE
+            );
+        }
+    );
+
+    const onCopyShareLink = useStableCallback(
+        async (collection: LibraryCollectionSummary) => {
+            if (!collection.shareId) {
+                showError(COPY_SHARE_LINK_MISSING_MESSAGE);
+                return;
+            }
+
+            await copyWithFeedback(
+                buildPublicCollectionShareUrl(collection.shareId),
+                `Public link for ${collection.name} copied to the clipboard.`,
+                COPY_SHARE_LINK_ERROR_MESSAGE
+            );
+        }
+    );
+
+    const onEnableShare = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             runGuardedAction({
                 action: async () => {
@@ -1192,7 +1179,7 @@ function useCollectionsController() {
                     });
 
                     if (result.status === ACTION_STATUS.SHARED) {
-                        syncShare(result.collection);
+                        sync.syncShare(result.collection);
                         const linkCopied = await copyToClipboard(
                             result.shareUrl
                         );
@@ -1214,7 +1201,7 @@ function useCollectionsController() {
         }
     );
 
-    const handleDisableShare = useStableCallback(
+    const onDisableShare = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             runGuardedAction({
                 action: async () => {
@@ -1223,7 +1210,7 @@ function useCollectionsController() {
                     });
 
                     if (result.status === ACTION_STATUS.DISABLED) {
-                        syncShare(result.collection);
+                        sync.syncShare(result.collection);
                         showSuccess(
                             `${collection.name} is no longer publicly shared.`
                         );
@@ -1239,15 +1226,13 @@ function useCollectionsController() {
         }
     );
 
-    const handleOpenLinks = useStableCallback(
+    const onOpenLinks = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             if (!ensureAccess(collection, "open")) {
                 return;
             }
 
-            const items = getCollectionItems(collection.id);
-            const urls = getItemUrls(items);
-
+            const urls = getItemUrls(getCollectionItems(collection.id));
             if (urls.length === 0) {
                 showError(EMPTY_LINKS_ERROR_MESSAGE);
                 return;
@@ -1263,14 +1248,13 @@ function useCollectionsController() {
         }
     );
 
-    const handleExportCsv = useStableCallback(
+    const onExportCsv = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             if (!ensureAccess(collection, "export")) {
                 return;
             }
 
             const items = getCollectionItems(collection.id);
-
             if (items.length === 0) {
                 showError(EMPTY_ITEMS_ERROR_MESSAGE);
                 return;
@@ -1288,7 +1272,6 @@ function useCollectionsController() {
                             name: `${slugify(collection.name) || "collection"}-links`,
                         }
                     );
-
                     showSuccess(`${collection.name} exported as CSV.`);
                 } catch {
                     showError(EXPORT_CSV_ERROR_MESSAGE);
@@ -1297,7 +1280,7 @@ function useCollectionsController() {
         }
     );
 
-    const handleSendToNotion = useStableCallback(
+    const onSendToNotion = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             runGuardedAction({
                 action: async () => {
@@ -1321,7 +1304,7 @@ function useCollectionsController() {
         }
     );
 
-    const handleUpdatePriority = useStableCallback(
+    const onUpdatePriority = useStableCallback(
         async (collectionId: string, priority: CollectionPriority) => {
             const key = `${PENDING_ACTION_PREFIX.PRIORITY}${collectionId}`;
             if (pendingActionIdsRef.current.has(key)) {
@@ -1337,7 +1320,7 @@ function useCollectionsController() {
             }
 
             pendingActionIdsRef.current.add(key);
-            syncPriority(collectionId, priority);
+            sync.syncPriority(collectionId, priority);
 
             try {
                 const result = await updateCollectionPrioritySafely({
@@ -1346,12 +1329,12 @@ function useCollectionsController() {
                 });
 
                 if (result.status === ACTION_STATUS.UPDATED) {
-                    syncPriority(
+                    sync.syncPriority(
                         result.collection.id,
                         result.collection.priority
                     );
                 } else {
-                    syncPriority(collectionId, previous);
+                    sync.syncPriority(collectionId, previous);
                     showError(result.message);
                 }
             } finally {
@@ -1360,7 +1343,7 @@ function useCollectionsController() {
         }
     );
 
-    const handleDuplicate = useStableCallback(
+    const onDuplicate = useStableCallback(
         (collection: LibraryCollectionSummary) => {
             setFeedback(null);
 
@@ -1374,7 +1357,7 @@ function useCollectionsController() {
                     return;
                 }
 
-                syncCreated({
+                sync.syncCreated({
                     assignedItemIds: result.assignedItemIds,
                     collection: result.collection,
                 });
@@ -1385,22 +1368,68 @@ function useCollectionsController() {
         }
     );
 
-    const handleFavoriteToggle = useStableCallback(
-        (collection: LibraryCollectionSummary) => {
-            const isFavorite = favoriteCollectionIdSet.has(collection.id);
-            setFavoriteCollectionIds((current) =>
-                toggleValue(current, collection.id)
-            );
-            showSuccess(
-                isFavorite
-                    ? `${collection.name} removed from Favorites.`
-                    : `${collection.name} added to Favorites.`
-            );
-        }
-    );
+    return {
+        onCopyLinks,
+        onCopyShareLink,
+        onCopyTitle,
+        onDisableShare,
+        onDuplicate,
+        onEnableShare,
+        onExportCsv,
+        onOpenLinks,
+        onSendToNotion,
+        onUpdatePriority,
+        pendingNotionCollectionIdSet,
+        pendingPriorityComboboxCollectionId,
+        pendingShareIdSet,
+        setPendingPriorityComboboxCollectionId,
+    };
+}
+
+function useCollectionPanelHotkeys() {
+    const { setIsCollectionsListOpen, setIsFavoritesListOpen } =
+        useCollectionsListStateStore();
+
+    const handleCollectionsListShortcutPress = useStableCallback(() => {
+        setIsCollectionsListOpen((current) => !current);
+    });
+
+    const handleFavoritesListShortcutPress = useStableCallback(() => {
+        setIsFavoritesListOpen((current) => !current);
+    });
+
+    useHotkeys("mod+c", handleCollectionsListShortcutPress, {
+        description: "Toggle collections panel",
+    });
+
+    useHotkeys("shift+mod+f", handleFavoritesListShortcutPress, {
+        description: "Toggle favorites panel",
+        preventDefault: true,
+    });
+}
+
+function useCollectionHoverHotkeys(input: {
+    hoveredCollectionRef: React.RefObject<LibraryCollectionSummary | null>;
+    onCopyLinks: (collection: LibraryCollectionSummary) => void;
+    requestDelete: (collection: LibraryCollectionSummary) => void;
+    requestRename: (collection: LibraryCollectionSummary) => void;
+    setPendingPriorityComboboxCollectionId: (id: string | null) => void;
+}) {
+    const { favoriteCollectionIdSet, toggleFavorite } =
+        useToggleCollectionFavorite();
+    const favoriteCollectionIdSetRef = React.useRef(favoriteCollectionIdSet);
+    favoriteCollectionIdSetRef.current = favoriteCollectionIdSet;
+
+    const {
+        hoveredCollectionRef,
+        onCopyLinks,
+        requestDelete,
+        requestRename,
+        setPendingPriorityComboboxCollectionId,
+    } = input;
 
     useHotkeys(
-        "e",
+        "alt+e",
         (event) => {
             const target = hoveredCollectionRef.current;
             if (target) {
@@ -1429,7 +1458,7 @@ function useCollectionsController() {
             const target = hoveredCollectionRef.current;
             if (target && target.itemCount > 0) {
                 event.preventDefault();
-                handleCopyLinks(target);
+                onCopyLinks(target);
             }
         },
         { description: "Copy links from hovered collection" }
@@ -1439,14 +1468,9 @@ function useCollectionsController() {
         "alt+f",
         (event) => {
             const target = hoveredCollectionRef.current;
-            if (target) {
-                const isFavorite = favoriteCollectionIdSetRef.current.has(
-                    target.id
-                );
-                if (!isFavorite) {
-                    event.preventDefault();
-                    handleFavoriteToggle(target);
-                }
+            if (target && !favoriteCollectionIdSetRef.current.has(target.id)) {
+                event.preventDefault();
+                toggleFavorite(target);
             }
         },
         { description: "Favorite hovered collection" }
@@ -1466,106 +1490,62 @@ function useCollectionsController() {
             preventDefault: true,
         }
     );
+}
 
-    const handleDismissFeedback = useStableCallback(() => {
-        setFeedback(null);
-    });
-
-    const handleComboboxValueChange = useStableCallback(
-        (nextValue: ComboboxValue | null) => {
-            if (!nextValue) {
-                return;
-            }
-
-            if (
-                nextValue.sortField !== collectionSortField ||
-                nextValue.sortQuery !== collectionTextMatchQuery
-            ) {
-                setCollectionSortField(nextValue.sortField);
-                if (nextValue.sortField === "text-match") {
-                    setCollectionTextMatchQuery(nextValue.sortQuery);
-                } else {
-                    setCollectionTextMatchQuery("");
-                }
-                setSortInputValue("");
-            }
-
-            if (nextValue.view !== collectionView) {
-                setCollectionView(nextValue.view);
-            }
-
-            setIsSortOpen(false);
-        }
+function useCollectionsController() {
+    const hoveredCollectionRef = React.useRef<LibraryCollectionSummary | null>(
+        null
     );
+    const sync = useCollectionSync(hoveredCollectionRef);
+    const dialogs = useCollectionDialogRequests();
+    const rowActions = useCollectionRowActions(sync);
+
+    useCollectionPanelHotkeys();
+    useCollectionHoverHotkeys({
+        hoveredCollectionRef,
+        onCopyLinks: rowActions.onCopyLinks,
+        requestDelete: dialogs.requestDelete,
+        requestRename: dialogs.requestRename,
+        setPendingPriorityComboboxCollectionId:
+            rowActions.setPendingPriorityComboboxCollectionId,
+    });
 
     return {
         actions: {
-            createSubmissionPendingRef,
-            onCopyLinks: handleCopyLinks,
-            onCopyShareLink: handleCopyShareLink,
-            onCopyTitle: handleCopyTitle,
-            onDelete: requestDelete,
-            onDisableShare: handleDisableShare,
-            onDismissFeedback: handleDismissFeedback,
-            onDuplicate: handleDuplicate,
-            onEnableShare: handleEnableShare,
-            onExportCsv: handleExportCsv,
-            onFavoriteToggle: handleFavoriteToggle,
-            onOpenLinks: handleOpenLinks,
-            onRename: requestRename,
-            onSendToNotion: handleSendToNotion,
-            onUpdatePriority: handleUpdatePriority,
-            setFavoriteCollectionIds,
-            setIsCollectionsListOpen,
-            setIsCreateOpen,
-            setIsFavoritesListOpen,
-            setIsRecommendationsOpen,
-            setPendingDelete,
-            setPendingPriorityComboboxCollectionId,
-            setPendingRename,
-            syncCreated,
-            syncDeleted,
-            syncItemTags,
-            syncName,
+            createSubmissionPendingRef: dialogs.createSubmissionPendingRef,
+            onCopyLinks: rowActions.onCopyLinks,
+            onCopyShareLink: rowActions.onCopyShareLink,
+            onCopyTitle: rowActions.onCopyTitle,
+            onDelete: dialogs.requestDelete,
+            onDisableShare: rowActions.onDisableShare,
+            onDuplicate: rowActions.onDuplicate,
+            onEnableShare: rowActions.onEnableShare,
+            onExportCsv: rowActions.onExportCsv,
+            onOpenLinks: rowActions.onOpenLinks,
+            onRename: dialogs.requestRename,
+            onSendToNotion: rowActions.onSendToNotion,
+            onUpdatePriority: rowActions.onUpdatePriority,
+            setIsCreateOpen: dialogs.setIsCreateOpen,
+            setPendingDelete: dialogs.setPendingDelete,
+            setPendingPriorityComboboxCollectionId:
+                rowActions.setPendingPriorityComboboxCollectionId,
+            setPendingRename: dialogs.setPendingRename,
+            syncCreated: sync.syncCreated,
+            syncDeleted: sync.syncDeleted,
+            syncName: sync.syncName,
         },
         state: {
-            collectionCount: collections.length,
-            collectionLabels,
-            collectionPreviewThumbnailUrlsById,
-            collectionSummaries,
-            createItemId,
-            favoriteCollectionIdSet,
-            favoriteCollectionSummaries,
-            favoriteItemIdSet,
-            favoriteItems,
-            feedback,
-            hasAnySelected,
+            createItemId: dialogs.createItemId,
             hoveredCollectionRef,
-            isCollectionsListOpen,
-            isCreateOpen,
-            isFavoritesListOpen,
-            isRecommendationsOpen,
-            onClearCollectionFilters,
-            onOpenFavoriteItem,
-            onSelectCollection,
-            onToggleItemFavorite,
-            pendingDelete,
-            pendingNotionCollectionIdSet,
-            pendingPriorityComboboxCollectionId,
-            pendingRename,
-            pendingShareIdSet,
-            requestCreate,
-            selectedCollectionIdSet,
-            showError,
-            showSuccess,
-            sort: {
-                inputValue: sortInputValue,
-                isOpen: isSortOpen,
-                onInputValueChange: setSortInputValue,
-                onOpenChange: setIsSortOpen,
-                onValueChange: handleComboboxValueChange,
-                value: comboboxValue,
-            },
+            isCreateOpen: dialogs.isCreateOpen,
+            pendingDelete: dialogs.pendingDelete,
+            pendingNotionCollectionIdSet:
+                rowActions.pendingNotionCollectionIdSet,
+            pendingPriorityComboboxCollectionId:
+                rowActions.pendingPriorityComboboxCollectionId,
+            pendingRename: dialogs.pendingRename,
+            pendingShareIdSet: rowActions.pendingShareIdSet,
+            requestCreate: dialogs.requestCreate,
         },
     };
 }
@@ -1591,7 +1571,7 @@ function useCollectionsActions(): CollectionsActions {
 }
 
 function useSmartCollectionsToggle() {
-    const { showError } = useCollectionsState();
+    const { showError } = useCollectionFeedbackWriter();
     const { disabled, isLoading, mutate } = useSmartCollectionsPreference();
 
     const setEnabled = useStableCallback(async (enabled: boolean) => {
@@ -1785,11 +1765,11 @@ function getCollectionItemStyle(
     const base = `color-mix(in srgb, ${color} ${isSelected ? 20 : 10}%, transparent)`;
 
     return {
-        "--accent-color": `color-mix(in srgb, ${color}, black 50%)`,
+        "--accent-color": `color-mix(in srgb, ${color}, light-dark(black, white) 45%)`,
         "--collection-background": isSelected
-            ? `color-mix(in srgb, ${base}, white 3%)`
-            : `color-mix(in srgb, ${base}, black 3%)`,
-        "--text-muted-color": `color-mix(in srgb, ${color} 16%, black 18%)`,
+            ? `color-mix(in srgb, ${base}, light-dark(white, black) 4%)`
+            : `color-mix(in srgb, ${base}, light-dark(black, white) 4%)`,
+        "--text-muted-color": `color-mix(in srgb, ${color} 28%, light-dark(black, white) 22%)`,
     };
 }
 
@@ -1951,8 +1931,9 @@ function CollectionsList({
     className,
     ...props
 }: React.ComponentProps<typeof Collapsible>) {
-    const { isCollectionsListOpen, requestCreate } = useCollectionsState();
-    const collectionsActions = useCollectionsActions();
+    const { isCollectionsListOpen, setIsCollectionsListOpen } =
+        useCollectionsListStateStore();
+    const { requestCreate } = useCollectionsState();
     const requestCreateRef = React.use(RequestCreateRefContext);
 
     React.useEffect(() => {
@@ -1969,7 +1950,7 @@ function CollectionsList({
         <Collapsible
             {...props}
             className={cn("relative", className)}
-            onOpenChange={collectionsActions.setIsCollectionsListOpen}
+            onOpenChange={setIsCollectionsListOpen}
             open={isCollectionsListOpen}
         />
     );
@@ -1979,8 +1960,11 @@ function CollectionsListTrigger({
     children,
     ...props
 }: React.ComponentProps<typeof CollapsibleTrigger>) {
-    const { collectionLabels, collectionSummaries, isCollectionsListOpen } =
-        useCollectionsState();
+    const { collectionSummaries } = useWorkspaceContext();
+    const { isCollectionsListOpen } = useCollectionsListStateStore();
+    const collectionLabels = collectionSummaries.map(
+        (collection) => collection.name
+    );
 
     return (
         <CollectionsListGroupTrigger
@@ -1999,11 +1983,19 @@ function CollectionsListFavorites({
     className,
     ...props
 }: React.ComponentProps<typeof Collapsible>) {
-    const { favoriteCollectionSummaries, favoriteItems, isFavoritesListOpen } =
-        useCollectionsState();
-    const { setIsFavoritesListOpen } = useCollectionsActions();
+    const { collectionSummaries, favoriteItems } = useWorkspaceContext();
+    const {
+        favoriteCollectionIds,
+        isFavoritesListOpen,
+        setIsFavoritesListOpen,
+    } = useCollectionsListStateStore();
+    const hasFavoriteCollections =
+        getFavoriteCollectionSummaries(
+            collectionSummaries,
+            favoriteCollectionIds
+        ).length > 0;
 
-    if (!(favoriteCollectionSummaries.length || favoriteItems.length)) {
+    if (!(hasFavoriteCollections || favoriteItems.length)) {
         return null;
     }
 
@@ -2022,8 +2014,13 @@ function CollectionsListFavoritesTrigger({
     ...props
 }: React.ComponentProps<typeof CollapsibleTrigger>) {
     const locale = useLocale();
-    const { favoriteCollectionSummaries, favoriteItems, isFavoritesListOpen } =
-        useCollectionsState();
+    const { collectionSummaries, favoriteItems } = useWorkspaceContext();
+    const { favoriteCollectionIds, isFavoritesListOpen } =
+        useCollectionsListStateStore();
+    const favoriteCollectionSummaries = getFavoriteCollectionSummaries(
+        collectionSummaries,
+        favoriteCollectionIds
+    );
     const collectionLabels = favoriteCollectionSummaries.map(
         (collection) => collection.name
     );
@@ -2175,7 +2172,7 @@ function CollectionsListGroupTrigger({
 function CollectionsListFavoritesCarouselContent({
     children,
 }: CollectionsListFavoritesCarouselContentProps) {
-    const { favoriteItems } = useCollectionsState();
+    const { favoriteItems } = useWorkspaceContext();
 
     if (!favoriteItems.length) {
         return null;
@@ -2195,7 +2192,7 @@ function CollectionsListFavoritesCarouselSlide({
 }: {
     item: LibraryItemWithCollections;
 }) {
-    const { onOpenFavoriteItem, onToggleItemFavorite } = useCollectionsState();
+    const { onOpenFavoriteItem, onToggleItemFavorite } = useWorkspaceContext();
     const isNote = item.kind === ITEM_KIND_NOTE;
     const previewImageUrl = itemPreviewImageUrl(item);
     const noteExcerpt = getNoteExcerpt(item.noteContentText);
@@ -2235,7 +2232,7 @@ function CollectionsListFavoritesCarouselSlide({
                     onClick={handleClick}
                 >
                     {isNote ? (
-                        <div className="flex size-full flex-col justify-between overflow-hidden bg-linear-to-br from-amber-50 via-background to-stone-100 p-1.5">
+                        <div className="flex size-full flex-col justify-between overflow-hidden bg-linear-to-br from-note-surface-from via-background to-note-surface-to p-1.5">
                             <p className="line-clamp-4 whitespace-pre-wrap text-left text-[9px] text-foreground leading-snug opacity-90">
                                 {noteExcerpt || "Open note"}
                             </p>
@@ -2263,7 +2260,7 @@ function CollectionsListFavoritesCarouselSlide({
                 side="top"
             >
                 {isNote ? (
-                    <div className="flex size-full flex-col justify-between overflow-hidden bg-linear-to-br from-amber-50 via-background to-stone-100 p-3">
+                    <div className="flex size-full flex-col justify-between overflow-hidden bg-linear-to-br from-note-surface-from via-background to-note-surface-to p-3">
                         <p className="line-clamp-6 whitespace-pre-wrap text-left text-foreground text-xs leading-snug">
                             {noteExcerpt || "Empty note"}
                         </p>
@@ -2283,7 +2280,12 @@ function CollectionsListFavoritesCarouselSlide({
 function CollectionsListFavoritesContent({
     children,
 }: CollectionsListFavoritesContentProps) {
-    const { favoriteCollectionSummaries } = useCollectionsState();
+    const { collectionSummaries } = useWorkspaceContext();
+    const { favoriteCollectionIds } = useCollectionsListStateStore();
+    const favoriteCollectionSummaries = getFavoriteCollectionSummaries(
+        collectionSummaries,
+        favoriteCollectionIds
+    );
 
     if (!favoriteCollectionSummaries.length) {
         return null;
@@ -2293,7 +2295,7 @@ function CollectionsListFavoritesContent({
 }
 
 function CollectionsListContent({ children }: CollectionsListContentProps) {
-    const { collectionSummaries } = useCollectionsState();
+    const { collectionSummaries } = useWorkspaceContext();
 
     if (!collectionSummaries.length) {
         return null;
@@ -2355,8 +2357,9 @@ function CollectionsListEmpty({
     className,
     ...props
 }: React.ComponentProps<"div">) {
-    const { collectionCount, collectionSummaries, requestCreate } =
-        useCollectionsState();
+    const { collections, collectionSummaries } = useWorkspaceContext();
+    const { requestCreate } = useCollectionsState();
+    const collectionCount = collections.length;
 
     const handleRequestCreate = useStableCallback(() => requestCreate());
 
@@ -2408,13 +2411,13 @@ function CollectionRecommendationItem({
 }: {
     template: CollectionTemplateOption;
 }) {
-    const { showError, showSuccess } = useCollectionsState();
+    const { showError, showSuccess } = useCollectionFeedbackWriter();
     const { syncCreated } = useCollectionsActions();
     const { mutate: mutateRecommendations } = useCollectionRecommendations();
     const [isCreating, setIsCreating] = React.useState(false);
 
     const handleClick = useStableCallback(
-        async (event: React.MouseEvent<HTMLButtonElement>) => {
+        async (event: React.SyntheticEvent) => {
             if (isCreating) {
                 event.preventDefault();
                 return;
@@ -2443,44 +2446,66 @@ function CollectionRecommendationItem({
 
     return (
         <div className="group relative flex select-none items-center">
-            <SidebarItem
-                className="w-full min-w-0 flex-1 justify-start rounded-lg pr-8 pl-10.5 text-left hover:bg-transparent"
-                render={
-                    <button
-                        disabled={isCreating}
-                        onClick={handleClick}
-                        type="button"
-                    />
-                }
-            >
-                <span className="absolute top-1/2 left-2.5 z-10 flex size-7 -translate-y-1/2 items-center justify-center rounded-md border-none bg-muted text-muted-foreground sm:size-6">
-                    <PlusIcon
-                        aria-hidden
-                        className="size-4 sm:size-3.5"
-                        focusable="false"
-                    />
-                </span>
-                <div className="flex min-w-0 flex-1 items-center gap-3 leading-none">
-                    <span className="max-w-full shrink-0 truncate font-medium text-sm">
-                        {template.name}
+            <PreviewCard>
+                <PreviewCardTrigger
+                    closeDelay={0}
+                    render={
+                        <SidebarItem
+                            className="w-full min-w-0 flex-1 justify-start rounded-lg pr-8 pl-10.5 text-left hover:bg-transparent"
+                            render={
+                                <button
+                                    disabled={isCreating}
+                                    onClick={handleClick}
+                                    type="button"
+                                />
+                            }
+                        />
+                    }
+                >
+                    <span className="absolute top-1/2 left-2.5 z-10 flex size-7 -translate-y-1/2 items-center justify-center rounded-md border-none bg-muted text-muted-foreground sm:size-6">
+                        <PlusIcon
+                            aria-hidden
+                            className="size-4 sm:size-3.5"
+                            focusable="false"
+                        />
                     </span>
-                </div>
-                {isCreating ? (
-                    <Spinner className="absolute right-3 size-3.5" />
-                ) : (
-                    <span className="absolute right-3 text-muted-foreground text-xs opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100">
-                        Create
-                    </span>
-                )}
-            </SidebarItem>
+                    <div className="flex min-w-0 flex-1 items-center gap-3 leading-none">
+                        <span className="max-w-full shrink-0 truncate font-medium text-sm">
+                            {template.name}
+                        </span>
+                    </div>
+                    {isCreating ? (
+                        <Spinner className="absolute right-3 size-3.5" />
+                    ) : (
+                        <span className="absolute right-3 text-muted-foreground text-xs opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100">
+                            Create
+                        </span>
+                    )}
+                </PreviewCardTrigger>
+                <PreviewCardPopup
+                    align="start"
+                    className="p-3"
+                    positionMethod="fixed"
+                    side="right"
+                >
+                    <div className="flex max-w-64 flex-col gap-1">
+                        <p className="font-medium text-xs leading-tight">
+                            {template.name}
+                        </p>
+                        <p className="text-muted-foreground text-xs leading-snug">
+                            {template.description}
+                        </p>
+                    </div>
+                </PreviewCardPopup>
+            </PreviewCard>
         </div>
     );
 }
 
 function CollectionsListRecommendations() {
-    const { collectionSummaries, isRecommendationsOpen } =
-        useCollectionsState();
-    const { setIsRecommendationsOpen } = useCollectionsActions();
+    const { collectionSummaries } = useWorkspaceContext();
+    const { isRecommendationsOpen, setIsRecommendationsOpen } =
+        useCollectionsListStateStore();
     const { items, isLoading } = useCollectionRecommendations();
 
     if (collectionSummaries.length === 0 || items.length === 0 || isLoading) {
@@ -2531,8 +2556,7 @@ function CollectionsListStatus({
     className,
     ...props
 }: React.ComponentProps<"p">) {
-    const { feedback } = useCollectionsState();
-    const { onDismissFeedback } = useCollectionsActions();
+    const { dismissFeedback, feedback } = useCollectionFeedback();
     const tone = feedback?.tone;
 
     if (!feedback?.message) {
@@ -2559,7 +2583,7 @@ function CollectionsListStatus({
             >
                 {feedback.message}
             </p>
-            <Button onClick={onDismissFeedback} size="xs" variant="ghost">
+            <Button onClick={dismissFeedback} size="xs" variant="ghost">
                 Dismiss
             </Button>
         </div>
@@ -2576,7 +2600,9 @@ function CollectionsListClearFilterButton({
     onClick: onClickProp,
     ...props
 }: React.ComponentProps<typeof Button>) {
-    const { hasAnySelected, onClearCollectionFilters } = useCollectionsState();
+    const { onClearCollectionFilters, selectedCollectionIds } =
+        useWorkspaceContext();
+    const hasAnySelected = selectedCollectionIds.length > 0;
 
     const onClick = useStableCallback(onClickProp);
     const handleClick = useStableCallback(
@@ -2620,15 +2646,81 @@ function CollectionsListSortingCombobox({
     render,
     ...props
 }: React.ComponentProps<typeof ComboboxTrigger>) {
-    const { sort, isCollectionsListOpen } = useCollectionsState();
+    const { setIsCollectionsListOpen } = useCollectionsListStateStore();
     const {
-        inputValue,
-        isOpen,
-        onInputValueChange,
-        onOpenChange,
-        onValueChange,
-        value,
-    } = sort;
+        collectionSortField,
+        collectionTextMatchQuery,
+        collectionView,
+        setCollectionSortField,
+        setCollectionTextMatchQuery,
+        setCollectionView,
+    } = useCollectionsSortStore();
+    const [inputValue, setInputValue] = React.useState("");
+    const [isSortOpen, setIsSortOpen] = React.useState(false);
+
+    const currentSortOption =
+        collectionSortField === "text-match"
+            ? {
+                  icon: ListFilter,
+                  label: `Sort by "${collectionTextMatchQuery}"`,
+              }
+            : (SORT_OPTION_BY_VALUE.get(collectionSortField) ?? null);
+
+    const value: ComboboxValue = {
+        icon: currentSortOption?.icon ?? ListFilter,
+        label: currentSortOption?.label ?? "Priority",
+        sortField: collectionSortField,
+        sortQuery: collectionTextMatchQuery,
+        view: collectionView,
+    };
+
+    const handleValueChange = useStableCallback(
+        (nextValue: ComboboxValue | null) => {
+            if (!nextValue) {
+                return;
+            }
+
+            if (
+                nextValue.sortField !== collectionSortField ||
+                nextValue.sortQuery !== collectionTextMatchQuery
+            ) {
+                setCollectionSortField(nextValue.sortField);
+                if (nextValue.sortField === "text-match") {
+                    setCollectionTextMatchQuery(nextValue.sortQuery);
+                } else {
+                    setCollectionTextMatchQuery("");
+                }
+                setInputValue("");
+            }
+
+            if (nextValue.view !== collectionView) {
+                setCollectionView(nextValue.view);
+            }
+
+            setIsSortOpen(false);
+        }
+    );
+
+    const handleOpenChange = useStableCallback((nextOpen: boolean) => {
+        setIsSortOpen(nextOpen);
+        if (nextOpen) {
+            setIsCollectionsListOpen(true);
+        }
+    });
+
+    useHotkeys(
+        "mod+f",
+        (event) => {
+            event.preventDefault();
+            setIsCollectionsListOpen(true);
+            setIsSortOpen(true);
+        },
+        {
+            description: "Sort and organize collections",
+            enabled: !isSortOpen,
+            preventDefault: true,
+        }
+    );
 
     return (
         <Combobox
@@ -2638,10 +2730,10 @@ function CollectionsListSortingCombobox({
             isItemEqualToValue={isComboboxValueEqual}
             items={getComboboxCollectionsSortingGroups(inputValue, value)}
             itemToStringValue={getComboboxOptionValue}
-            onInputValueChange={onInputValueChange}
-            onOpenChange={onOpenChange}
-            onValueChange={onValueChange}
-            open={isOpen}
+            onInputValueChange={setInputValue}
+            onOpenChange={handleOpenChange}
+            onValueChange={handleValueChange}
+            open={isSortOpen}
             value={value}
         >
             <ComboboxTrigger
@@ -2650,9 +2742,6 @@ function CollectionsListSortingCombobox({
                     render ?? (
                         <Button
                             aria-label="Sort and organize collections"
-                            className={
-                                isCollectionsListOpen ? undefined : "hidden"
-                            }
                             size="icon-xs"
                             variant="ghost"
                         />
@@ -2847,16 +2936,27 @@ function CollectionsListItem({
     style: styleProp,
     ...props
 }: CollectionsListItemProps) {
-    const { hoveredCollectionRef, selectedCollectionIdSet } =
-        useCollectionsState();
+    const { selectedCollectionIds } = useWorkspaceContext();
+    const { hoveredCollectionRef } = useCollectionsState();
     const handleMouseEnter = useStableCallback(onMouseEnterProp);
     const handleMouseLeave = useStableCallback(onMouseLeaveProp);
-    const isSelected = selectedCollectionIdSet.has(collection.id);
+    const isSelected = selectedCollectionIds.includes(collection.id);
     const style = getCollectionItemStyle(collection.name, isSelected);
+
+    React.useEffect(
+        () => () => {
+            if (hoveredCollectionRef.current?.id === collection.id) {
+                hoveredCollectionRef.current = null;
+                releaseHoverHotkeySurface("collection");
+            }
+        },
+        [collection.id, hoveredCollectionRef]
+    );
 
     const onMouseEnter = useStableCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {
             hoveredCollectionRef.current = collection;
+            claimHoverHotkeySurface("collection");
             handleMouseEnter?.(event);
         }
     );
@@ -2865,6 +2965,7 @@ function CollectionsListItem({
         (event: React.MouseEvent<HTMLDivElement>) => {
             if (hoveredCollectionRef.current?.id === collection.id) {
                 hoveredCollectionRef.current = null;
+                releaseHoverHotkeySurface("collection");
             }
             handleMouseLeave?.(event);
         }
@@ -2898,7 +2999,7 @@ function CollectionsListItemTrigger({
     ...props
 }: React.ComponentProps<typeof PreviewCardTrigger>) {
     const { collectionPreviewThumbnailUrlsById, onSelectCollection } =
-        useCollectionsState();
+        useWorkspaceContext();
     const { collection, isSelected } = useCollectionsListItemContext();
     // Intent from Base UI (delayed open / close). Armed is pointer presence so
     // we can warm images during the open delay without mount-time N preloads.
@@ -3001,7 +3102,7 @@ function CollectionsListItemPreviewStack({
     );
     const [isFading, setIsFading] = React.useState(false);
     const fadeTimeout = useTimeout();
-    const animationFrame = useAnimationFrame();
+    const rootRef = React.useRef<HTMLDivElement>(null);
 
     if (current.src !== activeSlide.src) {
         setOutgoing(current);
@@ -3014,12 +3115,14 @@ function CollectionsListItemPreviewStack({
             return;
         }
 
-        // Layout effect runs before paint, so the prepare frame (outgoing at
-        // opacity 1, incoming at 0) is committed first. The next animation
-        // frame starts the opacity transition.
-        animationFrame.request(() => {
-            setIsFading(true);
-        });
+        // Commit prepare styles (outgoing @1, incoming @0) before flipping to
+        // the fade classes. Without this forced reflow, React can paint only
+        // the end state and the opacity transition never runs.
+        const root = rootRef.current;
+        if (root) {
+            root.getBoundingClientRect();
+        }
+        setIsFading(true);
 
         fadeTimeout.start(PREVIEW_CROSSFADE_MS, () => {
             setOutgoing(null);
@@ -3027,18 +3130,22 @@ function CollectionsListItemPreviewStack({
         });
 
         return () => {
-            animationFrame.cancel();
             fadeTimeout.clear();
         };
-    }, [animationFrame, current.src, fadeTimeout, outgoing]);
+    }, [current.src, fadeTimeout, outgoing]);
 
     const handleCurrentError = useStableCallback(() => {
         onSlideError(current.src);
     });
 
+    const crossfadeStyle = {
+        transitionDuration: `${PREVIEW_CROSSFADE_MS}ms`,
+    } satisfies React.CSSProperties;
+
     return (
         <div
             className="relative w-full"
+            ref={rootRef}
             style={{ aspectRatio: String(current.aspectRatio) }}
         >
             {outgoing ? (
@@ -3052,10 +3159,9 @@ function CollectionsListItemPreviewStack({
                     )}
                     decoding="async"
                     draggable={false}
+                    key={outgoing.src}
                     src={outgoing.src}
-                    style={{
-                        transitionDuration: `${PREVIEW_CROSSFADE_MS}ms`,
-                    }}
+                    style={crossfadeStyle}
                 />
             ) : null}
             {/* biome-ignore lint/correctness/useImageSize: parent aspect-ratio drives layout */}
@@ -3067,11 +3173,10 @@ function CollectionsListItemPreviewStack({
                 )}
                 decoding="async"
                 draggable={false}
+                key={current.src}
                 onError={handleCurrentError}
                 src={current.src}
-                style={{
-                    transitionDuration: `${PREVIEW_CROSSFADE_MS}ms`,
-                }}
+                style={crossfadeStyle}
             />
         </div>
     );
@@ -3079,12 +3184,9 @@ function CollectionsListItemPreviewStack({
 
 /**
  * Display the collection name and, on hover, a faded list of its sources.
- *
- * Sources are hidden by default to keep the sidebar compact; they fade in
- * on hover as a secondary cue.
  */
 function CollectionsListItemValue() {
-    const { collection } = useCollectionsListItemContext();
+    const { collection, isSelected } = useCollectionsListItemContext();
 
     return (
         <div className="flex min-w-0 flex-1 items-center gap-3 leading-none">
@@ -3094,11 +3196,16 @@ function CollectionsListItemValue() {
             >
                 {collection.name}
             </span>
-            {collection.sources.length > 0 ? (
+            {isSelected ? (
+                <span className="max-w-full flex-1 truncate py-px text-[11px] text-muted-foreground opacity-100">
+                    <T>Unselect</T>
+                </span>
+            ) : null}
+            {isSelected || collection.sources.length === 0 ? null : (
                 <span className="max-w-full flex-1 truncate py-px text-[11px] text-muted-foreground opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-80">
                     {collection.sources.map(getSourceLabel).join(", ")}
                 </span>
-            ) : null}
+            )}
         </div>
     );
 }
@@ -3114,7 +3221,6 @@ function CollectionsListItemPriorityCombobox() {
         useCollectionsActions();
     const { collection } = useCollectionsListItemContext();
     const SelectedPriorityIcon = getPriorityOption(collection.priority).icon;
-
     const isOpen = pendingPriorityComboboxCollectionId === collection.id;
 
     const handleOpenChange = useStableCallback((open: boolean) => {
@@ -3192,7 +3298,7 @@ function CollectionsListItemPriorityCombobox() {
                         className="inline-block size-3.5 shrink-0"
                         focusable="false"
                     />
-                    <p className="text-[11px] text-muted-foreground leading-tight">
+                    <p className="text-[10px] text-muted-foreground leading-tight">
                         Set a priority to highlight your collections based on
                         their relevance to you
                     </p>
@@ -3397,11 +3503,11 @@ interface CollectionsListItemMetadataProps {
 function CollectionsListItemMetadata({
     children,
 }: CollectionsListItemMetadataProps) {
-    const { favoriteCollectionIdSet } = useCollectionsState();
+    const { favoriteCollectionIdSet, toggleFavorite } =
+        useToggleCollectionFavorite();
     const {
         onRename: onRenameAction,
         onDelete: onDeleteAction,
-        onFavoriteToggle: onFavoriteToggleAction,
         onDuplicate: onDuplicateAction,
         onUpdatePriority: onUpdatePriorityAction,
     } = useCollectionsActions();
@@ -3412,7 +3518,7 @@ function CollectionsListItemMetadata({
     const handleRename = useStableCallback(() => onRenameAction(collection));
     const handleDelete = useStableCallback(() => onDeleteAction(collection));
     const handleFavoriteToggle = useStableCallback(() => {
-        onFavoriteToggleAction(collection);
+        toggleFavorite(collection);
     });
     const handleMakeCopy = useStableCallback(() =>
         onDuplicateAction(collection)
@@ -3495,7 +3601,9 @@ function CollectionsListItemMetadata({
                                 focusable="false"
                             />
                             Rename
-                            <MenuShortcut>E</MenuShortcut>
+                            <MenuShortcut>
+                                <AltKbd />E
+                            </MenuShortcut>
                         </MenuItem>
                         <MenuItem onClick={handleMakeCopy}>
                             <CopyPlus
@@ -3541,7 +3649,8 @@ function CollectionsListItemMetadata({
 }
 
 function CollectionsRenameDialog() {
-    const { pendingRename, showSuccess } = useCollectionsState();
+    const { pendingRename } = useCollectionsState();
+    const { showSuccess } = useCollectionFeedbackWriter();
     const { syncName, setPendingRename } = useCollectionsActions();
     const isOpen = pendingRename !== null;
     const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -3712,7 +3821,8 @@ const INITIAL_CREATE_FORM_STATE: CreateFormState = {
 };
 
 function CollectionsCreateDialog() {
-    const { createItemId, isCreateOpen, showSuccess } = useCollectionsState();
+    const { createItemId, isCreateOpen } = useCollectionsState();
+    const { showSuccess } = useCollectionFeedbackWriter();
     const { createSubmissionPendingRef, setIsCreateOpen, syncCreated } =
         useCollectionsActions();
     const { disabled, setEnabled } = useSmartCollectionsToggle();
@@ -3949,7 +4059,8 @@ function CollectionsCreateDialog() {
                                     Collections keep your best saves and content
                                     in one place. Use them for ongoing goals, or
                                     just to keep things tidy. Smart Collections
-                                    can auto-assign matching entries to it.{" "}
+                                    can auto-assign matching entries to it – no
+                                    extra work for you.{" "}
                                     {disabled === true ? (
                                         <Button
                                             className="inline-flex h-fit! w-fit px-0 leading-tight sm:text-[11px]"
@@ -3960,7 +4071,7 @@ function CollectionsCreateDialog() {
                                             type="button"
                                             variant="link"
                                         >
-                                            Turn on Smart Collections
+                                            Enable Smart Collections
                                         </Button>
                                     ) : null}
                                 </p>
@@ -4030,8 +4141,7 @@ function CollectionsCreateDialog() {
                                             />
                                         </strong>{" "}
                                         can automatically assign collections to
-                                        entries that match these templates – no
-                                        extra work for you.
+                                        entries that match these templates.
                                     </p>
                                 </div>
                             </ComboboxPopup>
@@ -4052,7 +4162,8 @@ function CollectionsCreateDialog() {
 }
 
 function CollectionsDeleteDialog() {
-    const { pendingDelete, showSuccess, showError } = useCollectionsState();
+    const { pendingDelete } = useCollectionsState();
+    const { showError, showSuccess } = useCollectionFeedbackWriter();
     const { setPendingDelete, syncDeleted } = useCollectionsActions();
     const [isSubmitting, startDelete] = React.useTransition();
 

--- a/components/library/collections.tsx
+++ b/components/library/collections.tsx
@@ -588,11 +588,10 @@ function useToggleCollectionFavorite() {
 
     const toggleFavorite = useStableCallback(
         (collection: LibraryCollectionSummary) => {
-            let isNowFavorite = false;
-            setFavoriteCollectionIds((current) => {
-                isNowFavorite = !current.includes(collection.id);
-                return toggleValue(current, collection.id);
-            });
+            const isNowFavorite = !favoriteCollectionIdSet.has(collection.id);
+            setFavoriteCollectionIds((current) =>
+                toggleValue(current, collection.id)
+            );
             setFeedback({
                 message: isNowFavorite
                     ? `${collection.name} added to Favorites.`
@@ -1493,12 +1492,14 @@ function useCollectionHoverHotkeys(input: {
 }
 
 function useCollectionsController() {
+    const { selectedCollectionIds } = useWorkspaceContext();
     const hoveredCollectionRef = React.useRef<LibraryCollectionSummary | null>(
         null
     );
     const sync = useCollectionSync(hoveredCollectionRef);
     const dialogs = useCollectionDialogRequests();
     const rowActions = useCollectionRowActions(sync);
+    const selectedCollectionIdSet = new Set(selectedCollectionIds);
 
     useCollectionPanelHotkeys();
     useCollectionHoverHotkeys({
@@ -1546,6 +1547,7 @@ function useCollectionsController() {
             pendingRename: dialogs.pendingRename,
             pendingShareIdSet: rowActions.pendingShareIdSet,
             requestCreate: dialogs.requestCreate,
+            selectedCollectionIdSet,
         },
     };
 }
@@ -2936,11 +2938,11 @@ function CollectionsListItem({
     style: styleProp,
     ...props
 }: CollectionsListItemProps) {
-    const { selectedCollectionIds } = useWorkspaceContext();
-    const { hoveredCollectionRef } = useCollectionsState();
+    const { hoveredCollectionRef, selectedCollectionIdSet } =
+        useCollectionsState();
     const handleMouseEnter = useStableCallback(onMouseEnterProp);
     const handleMouseLeave = useStableCallback(onMouseLeaveProp);
-    const isSelected = selectedCollectionIds.includes(collection.id);
+    const isSelected = selectedCollectionIdSet.has(collection.id);
     const style = getCollectionItemStyle(collection.name, isSelected);
 
     React.useEffect(

--- a/components/library/composer.tsx
+++ b/components/library/composer.tsx
@@ -28,6 +28,7 @@ import {
     MetricsPanel,
     MetricsPanelChart,
     MetricsPanelHeader,
+    MetricsPanelSection,
     MetricsPanelTitle,
 } from "@/components/ui/metrics-panel";
 import {
@@ -41,11 +42,11 @@ import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import type { LibraryMetricsSnapshot } from "@/lib/collections/metrics";
 import { cn } from "@/lib/common/cn";
 import { formatPercent } from "@/lib/common/numbers";
-import {
-    Toolbar,
-    type AutocompleteRootChangeEventDetails,
-    type BaseUIEvent,
+import type {
+    AutocompleteRootChangeEventDetails,
+    BaseUIEvent,
 } from "@base-ui/react";
+import { Toolbar } from "@base-ui/react/toolbar";
 import { useStableCallback } from "@base-ui/utils/useStableCallback";
 import { Calligraph } from "calligraph";
 import { ChevronDown, CopyX, Grid2x2, Grid2x2X, SquarePen } from "lucide-react";
@@ -60,9 +61,9 @@ export interface PaletteStackEntry {
 }
 
 export interface CommandPaletteItem {
-    active?: boolean;
     description?: string;
     disabled?: boolean;
+    isActive?: boolean;
     label: string;
     onSelect: (
         event: BaseUIEvent<React.MouseEvent> | KeyboardEvent
@@ -282,9 +283,9 @@ export function ComposerActionNew() {
     const { onCreateNote } = useComposerActionsContext();
 
     return (
-        <ActionButton onClick={onCreateNote} title="New">
+        <ActionButton onClick={onCreateNote} title="Add new">
             <SquarePen className="inline-block size-3.5 shrink-0" />
-            &nbsp;New
+            &nbsp;Add new
         </ActionButton>
     );
 }
@@ -608,7 +609,7 @@ function CommandPaletteItemComponent({
                             {item.description}
                         </span>
                     ) : null}
-                    {item.active ? (
+                    {item.isActive ? (
                         <Badge variant="secondary">Active</Badge>
                     ) : null}
                     {item.shortcut ? (
@@ -629,10 +630,37 @@ function ComposerLibraryMetricsPanel({
     metrics: LibraryMetricsSnapshot;
     onClearPalette: () => void;
 }) {
-    const sourceTotal = metrics.sourceSegments.reduce(
-        (sum, segment) => sum + segment.value,
-        0
-    );
+    const {
+        duplicateCount,
+        itemCount,
+        sourceSegments,
+        uncollectedCount,
+        unreachableCount,
+    } = metrics;
+
+    const gapRows = [
+        uncollectedCount > 0
+            ? {
+                  key: "uncollected",
+                  label: "Not in Collections",
+                  value: formatShareValue(uncollectedCount, itemCount),
+              }
+            : null,
+        duplicateCount > 0
+            ? {
+                  key: "duplicates",
+                  label: "Duplicates",
+                  value: formatShareValue(duplicateCount, itemCount),
+              }
+            : null,
+        unreachableCount > 0
+            ? {
+                  key: "unreachable",
+                  label: "Unreachable",
+                  value: formatShareValue(unreachableCount, itemCount),
+              }
+            : null,
+    ].filter((row) => row !== null);
 
     return (
         <MetricsPanel>
@@ -652,50 +680,73 @@ function ComposerLibraryMetricsPanel({
             ) : null}
             <MetricsPanelHeader>
                 <MetricsPanelTitle render={<PopoverTitle />}>
-                    Display Breakdown
+                    Library Breakdown
                 </MetricsPanelTitle>
             </MetricsPanelHeader>
-            <MetricsPanelChart segments={metrics.sourceSegments} />
-            {metrics.sourceSegments.length > 0 ? (
+            <MetricsPanelSection>
+                <MetricsPanelChart segments={sourceSegments} />
                 <MetricsDataList>
-                    {metrics.sourceSegments.map((segment) => (
+                    {sourceSegments.map((segment) => (
                         <MetricsDataListItem
                             color={segment.color}
                             key={segment.key}
                             label={segment.label}
-                            value={formatSegmentValue(
-                                segment.value,
-                                sourceTotal
-                            )}
+                            value={formatShareValue(segment.value, itemCount)}
                         />
                     ))}
                 </MetricsDataList>
-            ) : null}
-            <MetricsDataList>
-                <MetricsDataListItem
-                    label="Favorites"
-                    value={metrics.favoriteCount}
-                />
-                <MetricsDataListItem
-                    label="Not in collections"
-                    value={metrics.uncollectedCount}
-                />
-                <MetricsDataListItem
-                    label="In collections"
-                    value={metrics.inCollectionCount}
-                />
-                <MetricsDataListItem label="Notes" value={metrics.noteCount} />
-            </MetricsDataList>
+            </MetricsPanelSection>
+            <MetricsPanelSection>
+                <MetricsDataList>
+                    <MetricsDataListItem
+                        label="Favorites"
+                        value={formatShareValue(
+                            metrics.favoriteCount,
+                            itemCount
+                        )}
+                    />
+                    <MetricsDataListItem
+                        label="Notes"
+                        value={formatShareValue(metrics.noteCount, itemCount)}
+                    />
+                </MetricsDataList>
+                <MetricsDataList>
+                    <MetricsDataListItem
+                        label="In Collections"
+                        value={formatShareValue(
+                            metrics.inCollectionCount,
+                            itemCount
+                        )}
+                    />
+                    {gapRows.length > 0
+                        ? gapRows.map(
+                              (row) =>
+                                  row && (
+                                      <MetricsDataListItem
+                                          key={row.key}
+                                          label={row.label}
+                                          value={row.value}
+                                      />
+                                  )
+                          )
+                        : null}
+                </MetricsDataList>
+            </MetricsPanelSection>
         </MetricsPanel>
     );
 }
 
-function formatSegmentValue(value: number, total: number): string {
+function formatShareValue(value: number, total: number): React.ReactNode {
     if (total <= 0) {
-        return String(value);
+        return value;
     }
-    const percent = (value / total) * 100;
-    return `${value} · ${formatPercent(percent)}`;
+    const percent = formatPercent((value / total) * 100);
+    return (
+        <>
+            {value}
+            <span className="text-muted-foreground/50"> · {percent}</span>
+        </>
+    );
 }
 
 function ActionButton({

--- a/components/library/composer.tsx
+++ b/components/library/composer.tsx
@@ -638,29 +638,32 @@ function ComposerLibraryMetricsPanel({
         unreachableCount,
     } = metrics;
 
-    const gapRows = [
-        uncollectedCount > 0
-            ? {
-                  key: "uncollected",
-                  label: "Not in Collections",
-                  value: formatShareValue(uncollectedCount, itemCount),
-              }
-            : null,
-        duplicateCount > 0
-            ? {
-                  key: "duplicates",
-                  label: "Duplicates",
-                  value: formatShareValue(duplicateCount, itemCount),
-              }
-            : null,
-        unreachableCount > 0
-            ? {
-                  key: "unreachable",
-                  label: "Unreachable",
-                  value: formatShareValue(unreachableCount, itemCount),
-              }
-            : null,
-    ].filter((row) => row !== null);
+    const gapRows: {
+        key: string;
+        label: string;
+        value: React.ReactNode;
+    }[] = [];
+    if (uncollectedCount > 0) {
+        gapRows.push({
+            key: "uncollected",
+            label: "Not in Collections",
+            value: formatShareValue(uncollectedCount, itemCount),
+        });
+    }
+    if (duplicateCount > 0) {
+        gapRows.push({
+            key: "duplicates",
+            label: "Duplicates",
+            value: formatShareValue(duplicateCount, itemCount),
+        });
+    }
+    if (unreachableCount > 0) {
+        gapRows.push({
+            key: "unreachable",
+            label: "Unreachable",
+            value: formatShareValue(unreachableCount, itemCount),
+        });
+    }
 
     return (
         <MetricsPanel>
@@ -718,18 +721,13 @@ function ComposerLibraryMetricsPanel({
                             itemCount
                         )}
                     />
-                    {gapRows.length > 0
-                        ? gapRows.map(
-                              (row) =>
-                                  row && (
-                                      <MetricsDataListItem
-                                          key={row.key}
-                                          label={row.label}
-                                          value={row.value}
-                                      />
-                                  )
-                          )
-                        : null}
+                    {gapRows.map((row) => (
+                        <MetricsDataListItem
+                            key={row.key}
+                            label={row.label}
+                            value={row.value}
+                        />
+                    ))}
                 </MetricsDataList>
             </MetricsPanelSection>
         </MetricsPanel>

--- a/components/library/hover-hotkey-surface.ts
+++ b/components/library/hover-hotkey-surface.ts
@@ -1,0 +1,22 @@
+/**
+ * Single active hover surface for library hotkeys. Card menus pin their
+ * hover target while open; without a shared claim, Alt+E / Alt+F would
+ * fire for both a pinned card and a hovered collection row.
+ */
+let activeSurface: "card" | "collection" | null = null;
+
+export function claimHoverHotkeySurface(surface: "card" | "collection"): void {
+    activeSurface = surface;
+}
+
+export function releaseHoverHotkeySurface(
+    surface: "card" | "collection"
+): void {
+    if (activeSurface === surface) {
+        activeSurface = null;
+    }
+}
+
+export function isHoverHotkeySurface(surface: "card" | "collection"): boolean {
+    return activeSurface === surface;
+}

--- a/components/library/hover-hotkey-surface.ts
+++ b/components/library/hover-hotkey-surface.ts
@@ -1,22 +1,29 @@
 /**
- * Single active hover surface for library hotkeys. Card menus pin their
- * hover target while open; without a shared claim, Alt+E / Alt+F would
- * fire for both a pinned card and a hovered collection row.
+ * Collection rows claim library hover hotkeys while the pointer is over them
+ * so card shortcuts (Alt+E / Alt+F / ⌘⌫ / S) do not also fire for a pinned or
+ * hovered card. Claim ids make release safe when the pointer crosses rows
+ * (leave of the previous row must not clear the next row's claim).
  */
-let activeSurface: "card" | "collection" | null = null;
+let activeClaimId = 0;
+let nextClaimId = 0;
 
-export function claimHoverHotkeySurface(surface: "card" | "collection"): void {
-    activeSurface = surface;
+/** @returns claim id to pass to {@link releaseCollectionHoverHotkeySurface} */
+export function claimCollectionHoverHotkeySurface(): number {
+    nextClaimId += 1;
+    activeClaimId = nextClaimId;
+    return activeClaimId;
 }
 
-export function releaseHoverHotkeySurface(
-    surface: "card" | "collection"
-): void {
-    if (activeSurface === surface) {
-        activeSurface = null;
+export function releaseCollectionHoverHotkeySurface(claimId: number): void {
+    if (activeClaimId === claimId) {
+        activeClaimId = 0;
     }
 }
 
-export function isHoverHotkeySurface(surface: "card" | "collection"): boolean {
-    return activeSurface === surface;
+export function clearCollectionHoverHotkeySurface(): void {
+    activeClaimId = 0;
+}
+
+export function isCollectionHoverHotkeySurface(): boolean {
+    return activeClaimId !== 0;
 }

--- a/components/ui/metrics-panel.tsx
+++ b/components/ui/metrics-panel.tsx
@@ -60,6 +60,23 @@ export function MetricsPanelTitle({
     });
 }
 
+export function MetricsPanelSection({
+    className,
+    render,
+    ...props
+}: useRender.ComponentProps<"section">) {
+    const defaultProps = {
+        className: cn("flex flex-col gap-2", className),
+        "data-slot": "metrics-panel-section",
+    };
+
+    return useRender({
+        defaultTagName: "section",
+        props: mergeProps<"section">(defaultProps, props),
+        render,
+    });
+}
+
 export function MetricsPanelChart({
     className,
     segments,
@@ -81,7 +98,7 @@ export function MetricsDataList({
     ...props
 }: useRender.ComponentProps<"dl">) {
     const defaultProps = {
-        className: cn("mt-1 flex flex-col gap-1.5", className),
+        className: cn("mt-1.5 flex flex-col gap-1.5", className),
         "data-slot": "metrics-data-list",
     };
 
@@ -111,7 +128,7 @@ export function MetricsDataListItem({
                             style={{ backgroundColor: color }}
                         />
                     ) : null}
-                    <span className="truncate">{label}</span>
+                    <span className="truncate font-medium">{label}</span>
                 </dt>
                 <dd className="text-foreground tabular-nums">{value}</dd>
             </>

--- a/lib/collections/metrics.test.ts
+++ b/lib/collections/metrics.test.ts
@@ -1,0 +1,71 @@
+import { buildLibraryMetrics } from "@/lib/collections/metrics";
+import {
+    LibraryItemLinkReachability,
+    LibraryItemSource,
+} from "@/prisma/client/enums";
+import { describe, expect, test } from "bun:test";
+
+describe("buildLibraryMetrics", () => {
+    test("summarizes sources, importance, and gaps", () => {
+        const metrics = buildLibraryMetrics({
+            getSourceLabel: (source) => source,
+            items: [
+                {
+                    collections: [{ id: "c1" }],
+                    favoritedAt: new Date("2026-01-01"),
+                    id: "a",
+                    kind: "bookmark",
+                    linkReachability: LibraryItemLinkReachability.reachable,
+                    source: LibraryItemSource.chrome_bookmarks,
+                    url: "https://www.example.com/post?utm_source=x",
+                },
+                {
+                    collections: [],
+                    favoritedAt: null,
+                    id: "b",
+                    kind: "bookmark",
+                    linkReachability: LibraryItemLinkReachability.unreachable,
+                    source: LibraryItemSource.other,
+                    url: "http://example.com/post/",
+                },
+                {
+                    collections: [{ id: "c1" }, { id: "c2" }],
+                    favoritedAt: null,
+                    id: "c",
+                    kind: "bookmark",
+                    linkReachability: null,
+                    source: LibraryItemSource.rss_feed,
+                    url: "https://news.ycombinator.com/item?id=1",
+                },
+                {
+                    collections: [],
+                    favoritedAt: new Date("2026-02-01"),
+                    id: "d",
+                    kind: "note",
+                    linkReachability: null,
+                    source: LibraryItemSource.cache_note,
+                    url: "about:blank",
+                },
+                {
+                    collections: [{ id: "c2" }],
+                    favoritedAt: null,
+                    id: "e",
+                    kind: "bookmark",
+                    source: LibraryItemSource.chrome_bookmarks,
+                    url: "https://github.com/anomalyco/opencode",
+                },
+            ],
+            libraryItemCount: 6,
+        });
+
+        expect(metrics.itemCount).toBe(5);
+        expect(metrics.libraryItemCount).toBe(6);
+        expect(metrics.favoriteCount).toBe(2);
+        expect(metrics.noteCount).toBe(1);
+        expect(metrics.inCollectionCount).toBe(3);
+        expect(metrics.uncollectedCount).toBe(2);
+        expect(metrics.duplicateCount).toBe(2);
+        expect(metrics.unreachableCount).toBe(1);
+        expect(metrics.sourceSegments[0]?.value).toBe(2);
+    });
+});

--- a/lib/collections/metrics.ts
+++ b/lib/collections/metrics.ts
@@ -1,6 +1,10 @@
+import { collectDuplicateBookmarkItemIds } from "@/lib/collections/library-quality";
 import { getChartColorsForKeys } from "@/lib/common/colors";
 import { ITEM_KIND_NOTE } from "@/lib/common/constants";
-import type { LibraryItemSource } from "@/prisma/client/enums";
+import {
+    LibraryItemLinkReachability,
+    type LibraryItemSource,
+} from "@/prisma/client/enums";
 
 export interface LibraryMetricsSegment {
     color: string;
@@ -10,7 +14,7 @@ export interface LibraryMetricsSegment {
 }
 
 export interface LibraryMetricsSnapshot {
-    collectionCount: number;
+    duplicateCount: number;
     favoriteCount: number;
     inCollectionCount: number;
     itemCount: number;
@@ -18,13 +22,17 @@ export interface LibraryMetricsSnapshot {
     noteCount: number;
     sourceSegments: LibraryMetricsSegment[];
     uncollectedCount: number;
+    unreachableCount: number;
 }
 
 export interface LibraryMetricsItem {
     collections: readonly { id: string }[];
     favoritedAt: Date | null;
+    id: string;
     kind: string;
+    linkReachability?: LibraryItemLinkReachability | null;
     source: LibraryItemSource;
+    url: string;
 }
 
 /**
@@ -41,10 +49,10 @@ export function buildLibraryMetrics({
     libraryItemCount: number;
 }): LibraryMetricsSnapshot {
     const sourceCounts = new Map<LibraryItemSource, number>();
-    const collectionIds = new Set<string>();
     let favoriteCount = 0;
     let noteCount = 0;
     let uncollectedCount = 0;
+    let unreachableCount = 0;
 
     for (const item of items) {
         sourceCounts.set(item.source, (sourceCounts.get(item.source) ?? 0) + 1);
@@ -58,8 +66,8 @@ export function buildLibraryMetrics({
         if (item.collections.length === 0) {
             uncollectedCount += 1;
         }
-        for (const collection of item.collections) {
-            collectionIds.add(collection.id);
+        if (item.linkReachability === LibraryItemLinkReachability.unreachable) {
+            unreachableCount += 1;
         }
     }
 
@@ -93,7 +101,7 @@ export function buildLibraryMetrics({
     const itemCount = items.length;
 
     return {
-        collectionCount: collectionIds.size,
+        duplicateCount: collectDuplicateBookmarkItemIds(items).size,
         favoriteCount,
         inCollectionCount: itemCount - uncollectedCount,
         itemCount,
@@ -101,5 +109,6 @@ export function buildLibraryMetrics({
         noteCount,
         sourceSegments,
         uncollectedCount,
+        unreachableCount,
     };
 }

--- a/lib/collections/service.ts
+++ b/lib/collections/service.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { templateDescriptionForNameKey } from "@/lib/collections/templates";
 import {
     LIBRARY_COLLECTION_TAG_SELECT,
     LIBRARY_ITEM_COLLECTIONS_INCLUDE,
@@ -424,6 +425,8 @@ export function createCollection({
     collection: LibraryCollectionSummary;
 }> {
     const normalized = normalizeCollectionName(name);
+    const resolvedDescription =
+        description ?? templateDescriptionForNameKey(normalized.nameKey);
 
     return prisma.$transaction(async (tx) => {
         const assignedItem = assignToItemId
@@ -443,7 +446,7 @@ export function createCollection({
 
         const collection = await tx.collection.create({
             data: {
-                description,
+                description: resolvedDescription,
                 items: assignedItem
                     ? { connect: { id: assignedItem.id } }
                     : undefined,
@@ -479,6 +482,8 @@ export function createCollectionFromItems({
     collection: LibraryCollectionSummary;
 }> {
     const normalized = normalizeCollectionName(name);
+    const resolvedDescription =
+        description ?? templateDescriptionForNameKey(normalized.nameKey);
 
     return prisma.$transaction(async (tx) => {
         await ensureCollectionNameAvailable(tx, {
@@ -496,7 +501,7 @@ export function createCollectionFromItems({
 
         const collection = await tx.collection.create({
             data: {
-                description,
+                description: resolvedDescription,
                 items: {
                     connect: toIdConnections(itemIds),
                 },

--- a/lib/collections/templates.ts
+++ b/lib/collections/templates.ts
@@ -1,3 +1,5 @@
+import { normalizeCollectionName } from "@/lib/common/strings";
+
 export interface CollectionTemplateOption {
     description: string;
     name: string;
@@ -112,3 +114,16 @@ export type TemplateValue = (typeof TEMPLATES)[number]["value"];
 export const TEMPLATE_BY_VALUE = new Map(
     TEMPLATES.map((template) => [template.value, template])
 );
+
+export const TEMPLATE_BY_NAME_KEY = new Map(
+    TEMPLATES.map((template) => [
+        normalizeCollectionName(template.name).nameKey,
+        template,
+    ])
+);
+
+export function templateDescriptionForNameKey(
+    nameKey: string
+): string | undefined {
+    return TEMPLATE_BY_NAME_KEY.get(nameKey)?.description;
+}

--- a/lib/intelligence/composer/service.ts
+++ b/lib/intelligence/composer/service.ts
@@ -222,9 +222,12 @@ async function runAskCacheAgentModel(args: {
                         };
                     }
 
-                    const patch = normalizeComposerPatchForContext(
-                        toolInput.patch,
-                        args.input
+                    const patch = resolveComposerPatchContradictions(
+                        normalizeComposerPatchForContext(
+                            toolInput.patch,
+                            args.input
+                        ),
+                        args.input.composerState
                     );
 
                     if (isNoopComposerPatch(patch, args.input.composerState)) {
@@ -432,6 +435,7 @@ function buildAskCacheInstructions(input: AskCacheRequest): string {
         "Use update_composer for requests that ask to show, find, filter, sort, group, or reset.",
         "Prefer update_composer over setting searchTerms alone when concrete filters (collections, domains, sources) are available.",
         "Use exact collection ids from the collection catalog when selecting collection filters.",
+        "selectedCollectionIds and collectionMembershipFilter: 'not-in-collections' are mutually exclusive — an item in a selected collection is by definition in a collection, so combining them always yields zero results. For 'things about X not in the X collection' requests, use collectionMembershipFilter: 'not-in-collections' with searchTerms about X, and set selectedCollectionIds: [] (omit only when none are already selected).",
         "Use exact domains from availableDomains when applying domainFilters.",
         "Composer filters are exact-match tools, not a semantic category classifier.",
         "Library entries usually do not contain category labels like software product, recipe, tutorial, or inspiration in caption, note text, URL, or metadata.",
@@ -547,20 +551,20 @@ function normalizeComposerPatchForContext(
 
     return {
         ...patch,
-        ...(patch.domainFilters
-            ? {
+        ...(patch.domainFilters === undefined
+            ? {}
+            : {
                   domainFilters: patch.domainFilters.filter((domain) =>
                       domains.has(domain)
                   ),
-              }
-            : {}),
-        ...(patch.selectedCollectionIds
-            ? {
+              }),
+        ...(patch.selectedCollectionIds === undefined
+            ? {}
+            : {
                   selectedCollectionIds: patch.selectedCollectionIds.filter(
                       (collectionId) => collectionIds.has(collectionId)
                   ),
-              }
-            : {}),
+              }),
     };
 }
 
@@ -576,6 +580,47 @@ function arraysEqual(left: string[], right: string[]): boolean {
         }
     }
     return true;
+}
+
+/**
+ * Resolves mutually exclusive collection filters so a valid patch never
+ * yields an empty result set. Prefer the field the model set explicitly:
+ * `not-in-collections` clears selections; selecting collections resets
+ * membership to `all`. Also heals latent contradictory state left by older
+ * patches so a partial update (e.g. searchTerms only) does not keep zero results.
+ */
+function resolveComposerPatchContradictions(
+    patch: AskCacheComposerPatch,
+    state: AskCacheRequest["composerState"]
+): AskCacheComposerPatch {
+    if (patch.reset) {
+        return patch;
+    }
+
+    const resultingMembership =
+        patch.collectionMembershipFilter ?? state.collectionMembershipFilter;
+    const resultingSelectedCollectionIds =
+        patch.selectedCollectionIds ?? state.selectedCollectionIds;
+
+    if (
+        resultingMembership !== "not-in-collections" ||
+        resultingSelectedCollectionIds.length === 0
+    ) {
+        return patch;
+    }
+
+    if (patch.collectionMembershipFilter === "not-in-collections") {
+        return { ...patch, selectedCollectionIds: [] };
+    }
+
+    if (
+        patch.selectedCollectionIds !== undefined &&
+        patch.selectedCollectionIds.length > 0
+    ) {
+        return { ...patch, collectionMembershipFilter: "all" };
+    }
+
+    return { ...patch, selectedCollectionIds: [] };
 }
 
 function isNoopComposerPatch(

--- a/lib/intelligence/index.ts
+++ b/lib/intelligence/index.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { serverEnv } from "@/env/server";
+import { templateDescriptionForNameKey } from "@/lib/collections/templates";
 import { COLLECTION_NAME_LENGTH_MAX } from "@/lib/collections/utils";
 import { createLogger } from "@/lib/common/logs/console/logger";
 import { GenAiProtectionError } from "@/lib/intelligence/error";
@@ -312,6 +313,16 @@ function summarizeJson(
     }
 }
 
+function resolveCollectionDescription(
+    collection: Pick<SmartCollectionCatalogEntry, "description" | "nameKey">
+): string | null {
+    return (
+        collection.description ??
+        templateDescriptionForNameKey(collection.nameKey) ??
+        null
+    );
+}
+
 function buildPrompt(
     item: SmartCollectionItem,
     collections: SmartCollectionCatalogEntry[]
@@ -319,17 +330,25 @@ function buildPrompt(
     const currentCollectionNames = item.collections.map(
         (collection) => collection.name
     );
-    const collectionCatalog = collections.map((collection) => ({
-        description: collection.description,
-        name: collection.name,
-    }));
+    const collectionCatalog = collections.map((collection) => {
+        const description = resolveCollectionDescription(collection);
+        if (description) {
+            return {
+                description,
+                name: collection.name,
+            };
+        }
+        return { name: collection.name };
+    });
     const sourceMetadata = summarizeJson(item.sourceMetadata);
 
     return [
         "Classify this single saved library item into user collections.",
         "Return strict JSON only.",
         "Always return both arrays, even when they are empty.",
-        "Use applyCollectionNames only for exact matches from AVAILABLE_COLLECTIONS.",
+        "Use applyCollectionNames only for exact collection names from AVAILABLE_COLLECTIONS.",
+        "When a collection includes a description, treat that description as the primary membership criteria — apply the collection only when the item clearly fits the described purpose, not merely because the name shares a keyword.",
+        "Prefer existing collections that have descriptions over creating new collections for the same theme.",
         `Choose at most ${SMART_COLLECTIONS_APPLY_COLLECTION_COUNT_MAX} existing collections and at most ${SMART_COLLECTIONS_NEW_COLLECTION_COUNT_MAX} new collections.`,
         "Create a new collection only when the item has a broad, reusable topic that will likely group many future saved items.",
         `New collection names must be concise taxonomy labels of at most ${SMART_COLLECTIONS_NEW_COLLECTION_WORD_COUNT_MAX} words, such as Design Systems or Personal Finance.`,
@@ -674,7 +693,7 @@ async function tryModelVariant(
                 responseJsonSchema: smartCollectionDecisionJsonSchema,
                 responseMimeType: MIME_TYPES.json,
                 systemInstruction:
-                    "You organize a user's saved media into focused collections. Be conservative, prefer existing collections, and create new collections only when there is a strong reusable theme.",
+                    "You organize a user's saved media into focused collections. Be conservative, prefer existing collections, and create new collections only when there is a strong reusable theme. When a collection has a description, use that description as the membership criteria for what belongs in it.",
                 temperature: MODEL_TEMPERATURE,
             },
             contents: variant.contents,
@@ -792,6 +811,25 @@ function mergeCollections(
     );
 }
 
+/**
+ * Prompt-only enrichment: fills missing template descriptions in memory so the
+ * model sees membership criteria. Does not write user collections.
+ */
+function withTemplateDescriptionsOnCatalog(
+    collections: SmartCollectionCatalogEntry[]
+): SmartCollectionCatalogEntry[] {
+    return collections.map((collection) => {
+        if (collection.description) {
+            return collection;
+        }
+        const description = templateDescriptionForNameKey(collection.nameKey);
+        if (!description) {
+            return collection;
+        }
+        return { ...collection, description };
+    });
+}
+
 function tokenizeCollectionName(name: string): string[] {
     return [
         ...name.toLocaleLowerCase().matchAll(COLLECTION_NAME_TOKEN_PATTERN),
@@ -883,8 +921,12 @@ async function applyDecisionToItem(args: {
         const upsertedCollections: SmartCollectionCatalogEntry[] = [];
 
         for (const newCollection of normalizedNewCollectionNames) {
+            const templateDescription = templateDescriptionForNameKey(
+                newCollection.nameKey
+            );
             const collection = await tx.collection.upsert({
                 create: {
+                    description: templateDescription,
                     name: newCollection.name,
                     nameKey: newCollection.nameKey,
                     userId: args.userId,
@@ -1035,7 +1077,7 @@ export async function autoTagLibraryItemsByIds(args: {
     }
 
     const ai = getGoogleGenAi();
-    let collections = initialCollections;
+    let collections = withTemplateDescriptionsOnCatalog(initialCollections);
     const itemsById = new Map(items.map((i) => [i.id, i]));
 
     for (const itemId of validItemIds) {


### PR DESCRIPTION
## Summary
- **Collections list:** refactor controller/actions (favorites feedback helpers, sorting, create dialog), improve hover/hotkey behavior shared with the library grid via `hover-hotkey-surface`
- **Browser cards:** pin hover target while menu/context menu/collection picker is open so Alt+F / Alt+E / ⌘⌫ keep working; claim exclusive hotkey surface vs collection rows; small menu/palette cleanups (incl. Wayback “6 months ago”)
- **Metrics:** replace derived `collectionCount` with **duplicate** and **unreachable** gap counts; composer panel shows share-style rows; add `MetricsPanelSection` + unit test
- **Templates:** resolve template description by name key on collection create (service) and for smart-collections prompting (in-memory catalog enrichment + new collection upsert)
- **Ask Cache composer:** heal mutually exclusive `selectedCollectionIds` + `collectionMembershipFilter: not-in-collections`; fix empty-array filter normalization; instruct the model about the contradiction

## Test plan
- [ ] Collections: create (template name gets description), rename, delete, favorite toggle, sort, share/Notion paths still work
- [ ] Hover a collection row and press collection shortcuts; open a card menu and confirm card shortcuts still target that card after pointer moves into the popup
- [ ] Hover a card while a collection is also under the pointer — only one surface owns Alt+E/F
- [ ] Composer metrics: duplicates/unreachable rows appear only when count > 0; favorites/notes/in-collection shares look correct
- [ ] Ask Cache: “things about X not in the X collection” does not combine selected collection + not-in-collections (zero-results bug)
- [ ] Smart collections: existing template-named collections without DB description still get criteria in the prompt; new template-named collections persist description
- [ ] `bun test lib/collections/metrics.test.ts`